### PR TITLE
Replacing navigation <a> with <button> & embed scroll fix

### DIFF
--- a/embed/embed.js
+++ b/embed/embed.js
@@ -23,8 +23,7 @@
     knowGodEmbed.appendChild(iframe);
 
     //listen for iframe height changes
-    var previousHeight = 0,
-      iframeTop = iframe.offsetTop;
+    var previousHeight = 0;
     var eventMethod = window.addEventListener
       ? 'addEventListener'
       : 'attachEvent';
@@ -38,9 +37,10 @@
         iframe.style.height = e.data + 'px';
 
         //scroll to top of iframe
-        if (window.pageYOffset > iframeTop) {
+        var newiframeTop = document.getElementById('knowGodEmbed').offsetTop;
+        if (window.pageYOffset > newiframeTop) {
           window.scrollTo({
-            top: iframeTop
+            top: newiframeTop
           });
         }
 

--- a/src/app/new-page/component/tract-page/tract-page.component.html
+++ b/src/app/new-page/component/tract-page/tract-page.component.html
@@ -43,30 +43,30 @@
       <ng-container *ngIf="(dir$ | async) === 'ltr'">
         <!-- If not first page -->
         <ng-container *ngIf="(isFirstPage$ | async) === false">
-          <a
+          <button
             (click)="previous()"
             class="button button-white far fa-arrow-left"
-          ></a>
+          ></button>
         </ng-container>
 
         <!-- If not last page -->
         <ng-container *ngIf="(isLastPage$ | async) === false">
-          <a (click)="next()" class="button far fa-arrow-right"></a>
+          <button (click)="next()" class="button far fa-arrow-right"></button>
         </ng-container>
       </ng-container>
 
       <ng-container *ngIf="(dir$ | async) === 'rtl'">
         <!-- If not first page -->
         <ng-container *ngIf="(isLastPage$ | async) === false">
-          <a (click)="next()" class="button far fa-arrow-left"></a>
+          <button (click)="next()" class="button far fa-arrow-left"></button>
         </ng-container>
 
         <!-- If not last page -->
         <ng-container *ngIf="(isFirstPage$ | async) === false">
-          <a
+          <button
             (click)="previous()"
             class="button button-white far fa-arrow-right"
-          ></a>
+          ></button>
         </ng-container>
       </ng-container>
     </div>


### PR DESCRIPTION
## Description
[GT-2093](https://jira.cru.org/browse/GT-2093)
The embed scroll to top functionality wasn't working. When clicking onto Next/Previous, the page scrolls to the very top of the page.
People thought this was due to the navigation being `<a>` tags. Switching them to `<button>` tags didn't fix the issue, but they should be buttons as they don't directly change the URL but instead invoke a function.

While testing, I discovered depending on where the iframe is located onLoad will determine where the window scrolls to. If the iframe is loaded at the top of the page and then pushed down after `onLoad`, On a next/previous click, it will scroll to the top of the page.

## Changes
- Switched `<a>` to `<button>` tags.
- Updated embed code to get the latest iframe offsetTop value just before triggering a window.scrollTo function.