### PR TITLE
Fixing scroll to top of iframe issue

### DIFF
--- a/embed/embed.js
+++ b/embed/embed.js
@@ -37,7 +37,9 @@
         iframe.style.height = e.data + 'px';
 
         //scroll to top of iframe
-        var newiframeTop = document.getElementById('knowGodEmbed').offsetTop;
+        var newiframeTop =
+          document.getElementById('knowGodEmbed').getBoundingClientRect().top +
+          window.scrollY;
         if (window.pageYOffset > newiframeTop) {
           window.scrollTo({
             top: newiframeTop


### PR DESCRIPTION
## Description
I changed the scroll top to call every time the user clicks a navigation button, but that didn't fix the issue. I believe the issue is also due to the way we fetch the top of the element. I have tested this in the browser on sites that currently send the user to the top of the page, and this change should fix that issue.


## Changes
Removed `.offsetTop()` and replaced it with `.getBoundingClientRect().top + window.scrollY` to get the offset of the element.