### PR TITLE
Fixing Deploy GHA pipeline

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -60,8 +60,14 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@v4
 
-      - name: Install AWSCLI
-        run: pip install --user awscli
+      - name: Install pipx
+        run: sudo apt-get install -y pipx
+      
+      - name: Ensure pipx is on the PATH
+        run: python3 -m pipx ensurepath
+
+      - name: Install AWSCLI with pipx
+        run: pipx install awscli
 
       - name: Node.js setup
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Description
In this PR, I fix the GitHub Action Deploy pipeline to prevent it from getting an error when installing AWCLI.

It seems that since our last deployment, GitHub has cracked down on the use of pip when installing an externally managed environment.

If you now want to install a global package, you need to do so in a virtual environment. To do this, we use pipe.