### PR TITLE
GitHub Actions - AWSCLI is pre-installed so we don't need to install it

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -60,15 +60,6 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@v4
 
-      - name: Install pipx
-        run: sudo apt-get install -y pipx
-      
-      - name: Ensure pipx is on the PATH
-        run: python3 -m pipx ensurepath
-
-      - name: Install AWSCLI with pipx
-        run: pipx install awscli
-
       - name: Node.js setup
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
As AWSCLI is pre-installed onto the ubuntu runner, so we don't need to install it on the Github action.

I added the installation after the pipeline stopped working since GHA didn't like using `pip` to install external environments. - https://github.com/CruGlobal/know-god-web/pull/157