### PR TITLE
Remove the text centered class from the first page

### DIFF
--- a/src/app/page/component/tract-page/tract-page.component.html
+++ b/src/app/page/component/tract-page/tract-page.component.html
@@ -2,7 +2,6 @@
   <div
     id="toolContent"
     [ngClass]="{
-      tc: (isFirstPage$ | async) || (isLastPage$ | async),
       firstPage: isFirstPage$ | async,
       lastPage: isLastPage$ | async,
       hasPageHeader: hasPageHeader


### PR DESCRIPTION
## Description
In this PR, I remove the text centered class from the first page. Not all first pages should be centred and if so, they can add the `tc` class.