### PR TITLE
Adding back text-align center to the last page

### DIFF
--- a/src/app/page/component/tract-page/tract-page.component.html
+++ b/src/app/page/component/tract-page/tract-page.component.html
@@ -2,6 +2,7 @@
   <div
     id="toolContent"
     [ngClass]="{
+      tc: isLastPage$ | async,
       firstPage: isFirstPage$ | async,
       lastPage: isLastPage$ | async,
       hasPageHeader: hasPageHeader


### PR DESCRIPTION
## Description

Adding `text-align: center` to the last page. This was mistakenly removed during my previous PR https://github.com/CruGlobal/know-god-web/pull/159, where I removed the `tc` class.