### PR TITLE
[no-Jira] Use HTTPS for links

### DIFF
--- a/src/app/page/component/tract-page/tract-page.component.html
+++ b/src/app/page/component/tract-page/tract-page.component.html
@@ -90,13 +90,13 @@
     >
       <footer id="toolFooter">
         <span
-          ><a href="http://godtoolsapp.com" target="_blank"
+          ><a href="https://godtoolsapp.com" target="_blank"
             >Learn more at godtoolsapp.com</a
           ></span
         >
         <span
           >© 1994-{{ currentYear }}
-          <a href="http://cru.org" target="_blank">Cru</a>. All Rights
+          <a href="https://cru.org" target="_blank">Cru</a>. All Rights
           Reserved.</span
         >
       </footer>


### PR DESCRIPTION
Use HTTPS for links to remove the "insecure" icon when hovering over them in Chromium browsers.