### PR TITLE
Removing 'new' from component names as it's no longer needed.

### DIFF
--- a/src/app/page/component/calltoaction/calltoaction.component.ts
+++ b/src/app/page/component/calltoaction/calltoaction.component.ts
@@ -7,7 +7,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-page-new-calltoaction',
+  selector: 'app-page-calltoaction',
   templateUrl: './calltoaction.component.html',
   styleUrls: ['./calltoaction.component.css']
 })

--- a/src/app/page/component/card/card.component.html
+++ b/src/app/page/component/card/card.component.html
@@ -13,6 +13,6 @@
     [innerHTML]="labelText"
   ></h4>
   <ng-container *ngIf="content && (isModal$ | async) === false">
-    <app-content-new-repeater [items]="content"></app-content-new-repeater>
+    <app-content-repeater [items]="content"></app-content-repeater>
   </ng-container>
 </div>

--- a/src/app/page/component/card/card.component.ts
+++ b/src/app/page/component/card/card.component.ts
@@ -8,7 +8,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-page-new-card',
+  selector: 'app-page-card',
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.css']
 })

--- a/src/app/page/component/content-accordion/content-accordion.component.css
+++ b/src/app/page/component/content-accordion/content-accordion.component.css
@@ -61,6 +61,6 @@
   max-height: 400px;
 }
 
-.accordion-content app-content-new-repeater {
+.accordion-content app-content-repeater {
   margin-top: 0;
 }

--- a/src/app/page/component/content-accordion/content-accordion.component.html
+++ b/src/app/page/component/content-accordion/content-accordion.component.html
@@ -6,9 +6,7 @@
         <i class="far fa-chevron-down"></i>
       </button>
       <div class="accordion-content">
-        <app-content-new-repeater
-          [items]="section.contents"
-        ></app-content-new-repeater>
+        <app-content-repeater [items]="section.contents"></app-content-repeater>
       </div>
     </div>
   </ng-container>

--- a/src/app/page/component/content-accordion/content-accordion.component.ts
+++ b/src/app/page/component/content-accordion/content-accordion.component.ts
@@ -7,7 +7,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-accordion',
+  selector: 'app-content-accordion',
   templateUrl: './content-accordion.component.html',
   styleUrls: ['./content-accordion.component.css']
 })

--- a/src/app/page/component/content-animation/content-animation.component.ts
+++ b/src/app/page/component/content-animation/content-animation.component.ts
@@ -13,7 +13,7 @@ import { Animation } from 'src/app/services/xml-parser-service/xmp-parser.servic
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-animation',
+  selector: 'app-content-animation',
   templateUrl: './content-animation.component.html',
   styleUrls: ['./content-animation.component.css']
 })

--- a/src/app/page/component/content-button/content-button.component.ts
+++ b/src/app/page/component/content-button/content-button.component.ts
@@ -8,7 +8,7 @@ import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-button',
+  selector: 'app-content-button',
   templateUrl: './content-button.component.html',
   styleUrls: ['./content-button.component.css']
 })

--- a/src/app/page/component/content-card/content-card.component.css
+++ b/src/app/page/component/content-card/content-card.component.css
@@ -6,7 +6,7 @@
   padding: 20px;
 }
 
-.card app-content-new-repeater {
+.card app-content-repeater {
   margin-top: 0;
 }
 

--- a/src/app/page/component/content-card/content-card.component.html
+++ b/src/app/page/component/content-card/content-card.component.html
@@ -4,7 +4,7 @@
     class="card"
     [ngStyle]="{ 'background-color': background }"
   >
-    <app-content-new-repeater [items]="contents"></app-content-new-repeater>
+    <app-content-repeater [items]="contents"></app-content-repeater>
   </div>
   <a
     *ngIf="card.isClickable"
@@ -12,6 +12,6 @@
     (click)="eventClick()"
     [ngStyle]="{ 'background-color': background }"
   >
-    <app-content-new-repeater [items]="contents"></app-content-new-repeater>
+    <app-content-repeater [items]="contents"></app-content-repeater>
   </a>
 </ng-container>

--- a/src/app/page/component/content-card/content-card.component.ts
+++ b/src/app/page/component/content-card/content-card.component.ts
@@ -8,7 +8,7 @@ import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-card',
+  selector: 'app-content-card',
   templateUrl: './content-card.component.html',
   styleUrls: ['./content-card.component.css']
 })

--- a/src/app/page/component/content-flow-item/content-flow-item.component.css
+++ b/src/app/page/component/content-flow-item/content-flow-item.component.css
@@ -6,7 +6,6 @@
   margin-top: 0px;
 }
 
-
-.flow-item app-content-new-repeater {
+.flow-item app-content-repeater {
   margin-top: 0;
 }

--- a/src/app/page/component/content-flow-item/content-flow-item.component.html
+++ b/src/app/page/component/content-flow-item/content-flow-item.component.html
@@ -1,3 +1,3 @@
 <div *ngIf="ready && !isHidden" class="flow-item">
-  <app-content-new-repeater [items]="contents"></app-content-new-repeater>
+  <app-content-repeater [items]="contents"></app-content-repeater>
 </div>

--- a/src/app/page/component/content-flow-item/content-flow-item.component.ts
+++ b/src/app/page/component/content-flow-item/content-flow-item.component.ts
@@ -13,7 +13,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-flow-item',
+  selector: 'app-content-flow-item',
   templateUrl: './content-flow-item.component.html',
   styleUrls: ['./content-flow-item.component.css']
 })

--- a/src/app/page/component/content-flow/content-flow.component.css
+++ b/src/app/page/component/content-flow/content-flow.component.css
@@ -3,7 +3,7 @@
   text-align: center;
 }
 
-.flow app-content-new-flow-item {
+.flow app-content-flow-item {
   margin: 0;
   display: inline-block;
 }

--- a/src/app/page/component/content-flow/content-flow.component.html
+++ b/src/app/page/component/content-flow/content-flow.component.html
@@ -1,9 +1,9 @@
 <ng-container *ngIf="ready">
   <div class="flow mw568">
-    <app-content-new-flow-item
+    <app-content-flow-item
       *ngFor="let item of items; trackBy: trackByFn"
       [item]="item"
     >
-    </app-content-new-flow-item>
+    </app-content-flow-item>
   </div>
 </ng-container>

--- a/src/app/page/component/content-flow/content-flow.component.ts
+++ b/src/app/page/component/content-flow/content-flow.component.ts
@@ -3,7 +3,7 @@ import { Flow } from 'src/app/services/xml-parser-service/xmp-parser.service';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-flow',
+  selector: 'app-content-flow',
   templateUrl: './content-flow.component.html',
   styleUrls: ['./content-flow.component.css']
 })

--- a/src/app/page/component/content-form/content-form.component.html
+++ b/src/app/page/component/content-form/content-form.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="ready && items && items.length">
   <form class="formContent mw568 indent">
-    <app-content-new-repeater [items]="items"></app-content-new-repeater>
+    <app-content-repeater [items]="items"></app-content-repeater>
   </form>
 </ng-container>

--- a/src/app/page/component/content-form/content-form.component.ts
+++ b/src/app/page/component/content-form/content-form.component.ts
@@ -15,7 +15,7 @@ import { PageService } from '../../service/page-service.service';
 import { ContentRepeaterComponent } from '../content-repeater/content-repeater.component';
 
 @Component({
-  selector: 'app-content-new-form',
+  selector: 'app-content-form',
   templateUrl: './content-form.component.html',
   styleUrls: ['./content-form.component.css']
 })

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -9,7 +9,7 @@ import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-image',
+  selector: 'app-content-image',
   templateUrl: './content-image.component.html',
   styleUrls: ['./content-image.component.css']
 })

--- a/src/app/page/component/content-input/content-input.component.ts
+++ b/src/app/page/component/content-input/content-input.component.ts
@@ -8,7 +8,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-input',
+  selector: 'app-content-input',
   templateUrl: './content-input.component.html',
   styleUrls: ['./content-input.component.css']
 })

--- a/src/app/page/component/content-link/content-link.component.ts
+++ b/src/app/page/component/content-link/content-link.component.ts
@@ -9,7 +9,7 @@ import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-link',
+  selector: 'app-content-link',
   templateUrl: './content-link.component.html',
   styleUrls: ['./content-link.component.css']
 })

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.css
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.css
@@ -2,8 +2,8 @@
   padding: 20px;
 }
 
-.multiselect-option app-content-new-repeater {
-  margin: 0
+.multiselect-option app-content-repeater {
+  margin: 0;
 }
 
 @media (max-width: 600px) {

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.html
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.html
@@ -7,5 +7,5 @@
   [ngClass]="{ selected: selected }"
   (click)="onClick()"
 >
-  <app-content-new-repeater [items]="contents"></app-content-new-repeater>
+  <app-content-repeater [items]="contents"></app-content-repeater>
 </div>

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.ts
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.ts
@@ -13,7 +13,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-multiselect-option',
+  selector: 'app-content-multiselect-option',
   templateUrl: './content-multiselect-option.component.html',
   styleUrls: ['./content-multiselect-option.component.css']
 })

--- a/src/app/page/component/content-multiselect/content-multiselect.component.css
+++ b/src/app/page/component/content-multiselect/content-multiselect.component.css
@@ -4,25 +4,22 @@
   gap: 15px;
 }
 
-.multiselect-option app-content-new-repeater {
+.multiselect-option app-content-repeater {
   margin: 0;
 }
 
-.multiselect[data-columns="1"] app-content-new-multiselect-option {
+.multiselect[data-columns='1'] app-content-multiselect-option {
   flex: 0 1 100%;
 }
 
-.multiselect[data-columns="2"] app-content-new-multiselect-option {
+.multiselect[data-columns='2'] app-content-multiselect-option {
   flex: 0 1 calc(50% - 15px);
 }
 
-.multiselect[data-columns="3"] app-content-new-multiselect-option {
+.multiselect[data-columns='3'] app-content-multiselect-option {
   flex: 0 1 calc(33.3% - 10px);
 }
 
-.multiselect[data-columns="4"] app-content-new-multiselect-option {
+.multiselect[data-columns='4'] app-content-multiselect-option {
   flex: 0 1 calc(25% - 11.25px);
-
 }
-
-

--- a/src/app/page/component/content-multiselect/content-multiselect.component.html
+++ b/src/app/page/component/content-multiselect/content-multiselect.component.html
@@ -1,9 +1,9 @@
 <ng-container *ngIf="ready">
   <div class="multiselect mw568" attr.data-columns="{{ columns }}">
-    <app-content-new-multiselect-option
+    <app-content-multiselect-option
       *ngFor="let option of options; trackBy: trackByFn"
       [item]="option"
     >
-    </app-content-new-multiselect-option>
+    </app-content-multiselect-option>
   </div>
 </ng-container>

--- a/src/app/page/component/content-multiselect/content-multiselect.component.ts
+++ b/src/app/page/component/content-multiselect/content-multiselect.component.ts
@@ -6,7 +6,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-multiselect',
+  selector: 'app-content-multiselect',
   templateUrl: './content-multiselect.component.html',
   styleUrls: ['./content-multiselect.component.css']
 })

--- a/src/app/page/component/content-paragraph/content-paragraph.component.html
+++ b/src/app/page/component/content-paragraph/content-paragraph.component.html
@@ -1,3 +1,3 @@
 <ng-container *ngIf="ready && items && items.length">
-  <app-content-new-repeater [items]="items"></app-content-new-repeater>
+  <app-content-repeater [items]="items"></app-content-repeater>
 </ng-container>

--- a/src/app/page/component/content-paragraph/content-paragraph.component.ts
+++ b/src/app/page/component/content-paragraph/content-paragraph.component.ts
@@ -5,7 +5,7 @@ import {
 } from 'src/app/services/xml-parser-service/xmp-parser.service';
 
 @Component({
-  selector: 'app-content-new-paragraph',
+  selector: 'app-content-paragraph',
   templateUrl: './content-paragraph.component.html',
   styleUrls: ['./content-paragraph.component.css']
 })

--- a/src/app/page/component/content-repeater/content-repeater.component.html
+++ b/src/app/page/component/content-repeater/content-repeater.component.html
@@ -1,65 +1,65 @@
 <ng-container *ngIf="ready && content && content.length">
   <ng-container *ngFor="let item of content; let order = index">
-    <app-content-new-accordion
+    <app-content-accordion
       *ngIf="item.type === 'accordion'"
       [item]="item.content"
-    ></app-content-new-accordion>
-    <app-content-new-animation
+    ></app-content-accordion>
+    <app-content-animation
       *ngIf="item.type === 'animation'"
       [item]="item.content"
-    ></app-content-new-animation>
-    <app-content-new-button
+    ></app-content-animation>
+    <app-content-button
       *ngIf="item.type === 'button'"
       [item]="item.content"
-    ></app-content-new-button>
-    <app-content-new-form
+    ></app-content-button>
+    <app-content-form
       *ngIf="item.type === 'form'"
       [item]="item.content"
-    ></app-content-new-form>
-    <app-content-new-image
+    ></app-content-form>
+    <app-content-image
       *ngIf="item.type === 'image'"
       [item]="item.content"
-    ></app-content-new-image>
-    <app-content-new-input
+    ></app-content-image>
+    <app-content-input
       *ngIf="item.type === 'input'"
       [item]="item.content"
-    ></app-content-new-input>
-    <app-content-new-link
+    ></app-content-input>
+    <app-content-link
       *ngIf="item.type === 'link'"
       [item]="item.content"
-    ></app-content-new-link>
-    <app-content-new-paragraph
+    ></app-content-link>
+    <app-content-paragraph
       *ngIf="item.type === 'paragraph'"
       [item]="item.content"
-    ></app-content-new-paragraph>
-    <app-content-new-tabs
+    ></app-content-paragraph>
+    <app-content-tabs
       *ngIf="item.type === 'tabs'"
       [item]="item.content"
-    ></app-content-new-tabs>
-    <app-content-new-text
+    ></app-content-tabs>
+    <app-content-text
       *ngIf="item.type === 'text'"
       [item]="item.content"
-    ></app-content-new-text>
-    <app-content-new-video
+    ></app-content-text>
+    <app-content-video
       *ngIf="item.type === 'video'"
       [item]="item.content"
-    ></app-content-new-video>
-    <app-content-new-spacer
+    ></app-content-video>
+    <app-content-spacer
       *ngIf="item.type === 'spacer'"
       [item]="item.content"
-    ></app-content-new-spacer>
-    <app-content-new-multiselect
+    ></app-content-spacer>
+    <app-content-multiselect
       *ngIf="item.type === 'multiselect'"
       [item]="item.content"
-    ></app-content-new-multiselect>
-    <app-content-new-flow
+    ></app-content-multiselect>
+    <app-content-flow
       *ngIf="item.type === 'flow'"
       [item]="item.content"
-    ></app-content-new-flow>
-    <app-content-new-card
+    ></app-content-flow>
+    <app-content-card
       *ngIf="item.type === 'card'"
       [item]="item.content"
-    ></app-content-new-card>
+    ></app-content-card>
     <app-training-tip
       *ngIf="item.type === 'tip'"
       [item]="item.content"

--- a/src/app/page/component/content-repeater/content-repeater.component.ts
+++ b/src/app/page/component/content-repeater/content-repeater.component.ts
@@ -15,7 +15,7 @@ import {
 import { ContentInputComponent } from '../content-input/content-input.component';
 
 @Component({
-  selector: 'app-content-new-repeater',
+  selector: 'app-content-repeater',
   templateUrl: './content-repeater.component.html',
   styleUrls: ['./content-repeater.component.css']
 })

--- a/src/app/page/component/content-spacer/content-spacer.component.ts
+++ b/src/app/page/component/content-spacer/content-spacer.component.ts
@@ -4,7 +4,7 @@ import { Spacer } from 'src/app/services/xml-parser-service/xmp-parser.service';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-spacer',
+  selector: 'app-content-spacer',
   templateUrl: './content-spacer.component.html',
   styleUrls: ['./content-spacer.component.css']
 })

--- a/src/app/page/component/content-tabs/content-tabs.component.html
+++ b/src/app/page/component/content-tabs/content-tabs.component.html
@@ -3,9 +3,7 @@
     <ng-container *ngIf="tab.tab && tab.contents">
       <div class="tabContent">
         <p>{{ tab.tab.label.text }}</p>
-        <app-content-new-repeater
-          [items]="tab.contents"
-        ></app-content-new-repeater>
+        <app-content-repeater [items]="tab.contents"></app-content-repeater>
       </div>
     </ng-container>
   </ng-container>

--- a/src/app/page/component/content-tabs/content-tabs.component.ts
+++ b/src/app/page/component/content-tabs/content-tabs.component.ts
@@ -13,7 +13,7 @@ interface TabWithContent {
 }
 
 @Component({
-  selector: 'app-content-new-tabs',
+  selector: 'app-content-tabs',
   templateUrl: './content-tabs.component.html',
   styleUrls: ['./content-tabs.component.css']
 })

--- a/src/app/page/component/content-text/content-text.component.ts
+++ b/src/app/page/component/content-text/content-text.component.ts
@@ -7,7 +7,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-text',
+  selector: 'app-content-text',
   templateUrl: './content-text.component.html',
   styleUrls: ['./content-text.component.css']
 })

--- a/src/app/page/component/content-video/content-video.component.ts
+++ b/src/app/page/component/content-video/content-video.component.ts
@@ -5,7 +5,7 @@ import { Video } from 'src/app/services/xml-parser-service/xmp-parser.service';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-content-new-video',
+  selector: 'app-content-video',
   templateUrl: './content-video.component.html',
   styleUrls: ['./content-video.component.css']
 })

--- a/src/app/page/component/modal/modal.component.html
+++ b/src/app/page/component/modal/modal.component.html
@@ -8,6 +8,6 @@
   </div>
 
   <ng-container *ngIf="content">
-    <app-content-new-repeater [items]="content"></app-content-new-repeater>
+    <app-content-repeater [items]="content"></app-content-repeater>
   </ng-container>
 </ng-container>

--- a/src/app/page/component/modal/modal.component.ts
+++ b/src/app/page/component/modal/modal.component.ts
@@ -9,7 +9,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-page-new-modal',
+  selector: 'app-page-modal',
   templateUrl: './modal.component.html',
   styleUrls: ['./modal.component.css']
 })

--- a/src/app/page/component/page-header/page-header.component.ts
+++ b/src/app/page/component/page-header/page-header.component.ts
@@ -8,7 +8,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-page-new-header',
+  selector: 'app-page-header',
   templateUrl: './page-header.component.html',
   styleUrls: ['./page-header.component.css']
 })

--- a/src/app/page/component/page-hero/page-hero.component.css
+++ b/src/app/page/component/page-hero/page-hero.component.css
@@ -3,7 +3,6 @@
   display: block;
 }
 
-
-app-content-new-repeater {
+app-content-repeater {
   margin-top: 0;
 }

--- a/src/app/page/component/page-hero/page-hero.component.html
+++ b/src/app/page/component/page-hero/page-hero.component.html
@@ -11,5 +11,5 @@
   <h2 class="mw568 tc firstHeading" [innerHTML]="headingText"></h2>
 </ng-container>
 <ng-container *ngIf="ready && content && (isForm$ | async) === false">
-  <app-content-new-repeater [items]="content"></app-content-new-repeater>
+  <app-content-repeater [items]="content"></app-content-repeater>
 </ng-container>

--- a/src/app/page/component/page-hero/page-hero.component.ts
+++ b/src/app/page/component/page-hero/page-hero.component.ts
@@ -16,7 +16,7 @@ import {
 import { PageService } from '../../service/page-service.service';
 
 @Component({
-  selector: 'app-page-new-hero',
+  selector: 'app-page-hero',
   templateUrl: './page-hero.component.html',
   styleUrls: ['./page-hero.component.css']
 })

--- a/src/app/page/component/page/cyoa-page/cyoa-page.component.html
+++ b/src/app/page/component/page/cyoa-page/cyoa-page.component.html
@@ -8,7 +8,7 @@
     >
       <img src="assets/img/back-arrow.png" alt="navigate back" />
     </a>
-    <app-content-new-repeater [items]="content"></app-content-new-repeater>
+    <app-content-repeater [items]="content"></app-content-repeater>
 
     <ng-container
       *ngIf="(isModal$ | async) === false && (isModal$ | async) === false"

--- a/src/app/page/component/page/default-page.css
+++ b/src/app/page/component/page/default-page.css
@@ -85,11 +85,11 @@
   margin-left: 12px;
 }
 
-#toolContent.hasPageHeader > app-page-new-hero > .stepHeading {
+#toolContent.hasPageHeader > app-page-hero > .stepHeading {
   padding: 0;
 }
 
-#toolContent.hasPageHeader > app-page-new-hero > .stepHeading > h1 {
+#toolContent.hasPageHeader > app-page-hero > .stepHeading > h1 {
   display: none;
 }
 
@@ -247,17 +247,17 @@ div.cardContent:not(.hasHading) {
   margin-top: 48px !important;
 }
 
-app-content-new-repeater > app-content-new-text {
+app-content-repeater > app-content-text {
   margin-top: 24px;
 }
 @media screen and (min-width: 616px) {
-  div.cardContent.hasHeading app-content-new-text > p.textContent,
-  div.tabContent app-content-new-text > p.textContent {
+  div.cardContent.hasHeading app-content-text > p.textContent,
+  div.tabContent app-content-text > p.textContent {
     padding-left: 44px;
     padding-right: 44px;
   }
 
-  .modal-paragraph > app-content-new-text > p.textContent {
+  .modal-paragraph > app-content-text > p.textContent {
     padding-left: 44px;
     padding-right: 44px;
   }

--- a/src/app/page/component/page/tract-page/tract-page.component.css
+++ b/src/app/page/component/page/tract-page/tract-page.component.css
@@ -1,4 +1,4 @@
-app-tract-new-page {
+app-tract-page {
   width: 100%;
   display: block;
 }

--- a/src/app/page/component/page/tract-page/tract-page.component.html
+++ b/src/app/page/component/page/tract-page/tract-page.component.html
@@ -8,36 +8,33 @@
       hasPageHeader: hasPageHeader
     }"
   >
-    <app-page-new-header
+    <app-page-header
       *ngIf="header && (isModal$ | async) === false"
       [header]="header"
-    ></app-page-new-header>
-    <app-page-new-hero
+    ></app-page-header>
+    <app-page-hero
       *ngIf="hero && (isModal$ | async) === false"
       [hero]="hero"
-    ></app-page-new-hero>
-    <app-page-new-hero
+    ></app-page-hero>
+    <app-page-hero
       *ngIf="content && (isModal$ | async) === false"
       [hero]="{ content: content }"
     >
-    </app-page-new-hero>
+    </app-page-hero>
     <ng-container *ngIf="cards && cards.length && (isModal$ | async) === false">
-      <app-page-new-card
-        *ngFor="let card of cards"
-        [card]="card"
-      ></app-page-new-card>
+      <app-page-card *ngFor="let card of cards" [card]="card"></app-page-card>
     </ng-container>
-    <app-page-new-calltoaction
+    <app-page-calltoaction
       *ngIf="
         callToAction &&
         (isForm$ | async) === false &&
         (isModal$ | async) === false
       "
       [item]="callToAction"
-    ></app-page-new-calltoaction>
+    ></app-page-calltoaction>
 
     <ng-container *ngIf="modal && (isModal$ | async)">
-      <app-page-new-modal [modal]="modal"></app-page-new-modal>
+      <app-page-modal [modal]="modal"></app-page-modal>
     </ng-container>
 
     <div

--- a/src/app/page/component/page/tract-page/tract-page.component.ts
+++ b/src/app/page/component/page/tract-page/tract-page.component.ts
@@ -21,7 +21,7 @@ import {
 import { PageService } from '../../../service/page-service.service';
 
 @Component({
-  selector: 'app-tract-new-page',
+  selector: 'app-tract-page',
   templateUrl: './tract-page.component.html',
   styleUrls: ['../default-page.css'],
   encapsulation: ViewEncapsulation.None

--- a/src/app/page/page.component.html
+++ b/src/app/page/page.component.html
@@ -45,13 +45,13 @@
       >
       </app-cyoa-page>
 
-      <app-tract-new-page
+      <app-tract-page
         *ngIf="resourceType === 'tract'"
         [page]="activePage"
         [order]="activePageOrder"
         [totalPages]="totalPages"
       >
-      </app-tract-new-page>
+      </app-tract-page>
     </div>
 
     <ng-container *ngIf="bookNotAvailableInLanguage">

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -41,7 +41,7 @@ interface LiveShareSubscriptionPayload {
 }
 
 @Component({
-  selector: 'app-page-new',
+  selector: 'app-page',
   templateUrl: './page.component.html',
   styleUrls: ['./page.component.css'],
   encapsulation: ViewEncapsulation.None
@@ -288,11 +288,11 @@ export class PageComponent implements OnInit, OnDestroy {
           ParserConfig.Companion.FEATURE_CONTENT_CARD
         ])
         .withParseTips(false);
-      const newParser = new ManifestParser(this.pullParserFactory, config);
+      const parser = new ManifestParser(this.pullParserFactory, config);
       const controller = new AbortController();
       const signal = controller.signal;
       try {
-        newParser.parseManifest(fileName, signal).then((data) => {
+        parser.parseManifest(fileName, signal).then((data) => {
           const { manifest } = data as XmlParserData;
           this._pageBookManifest = manifest;
 


### PR DESCRIPTION
## Description
In this PR, I have renamed the components so we no longer have `new` in the name.

I added `new` in the beginning because we had to build the new web page alongside the old one. Now that the old one is removed, we can rename all the component names.