### PR TITLE
Fix iframes and links to the old URL format

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -54,6 +54,11 @@ import { SharingModalComponent } from './shared/sharing-modal/sharing-modal.comp
 
 const appRoutes: Routes = [
   {
+    path: ':langId/:bookId',
+    // Redirecting old URL format to the new one
+    redirectTo: ':langId/tool/v1/:bookId'
+  },
+  {
     path: ':langId/:bookId/:page',
     // Redirecting old URL format to the new one
     redirectTo: ':langId/tool/v1/:bookId/:page',


### PR DESCRIPTION
## Bug
When we deployed the code on PR https://github.com/CruGlobal/know-god-web/pull/221, we noticed that the redirect from the old URL does not work if the page number is not specified.

## Fix
We added a new redirect that redirects the old URL format of the book to the new one when the page number is not specified.