### PR TITLE
GT-2868 Fix language selector issue

### DIFF
--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -619,6 +619,73 @@ export const mockPageComponent = {
   }
 };
 
+export const mockBooksData = {
+  data: [
+    {
+      id: '1',
+      attributes: {
+        'resource-type': 'lesson',
+        'attr-hidden': false,
+        abbreviation: 'lesson1'
+      }
+    },
+    {
+      id: '2',
+      attributes: {
+        'resource-type': 'tract',
+        'attr-hidden': false,
+        abbreviation: 'tract1'
+      }
+    },
+    {
+      id: '3',
+      attributes: {
+        'resource-type': 'lesson',
+        'attr-hidden': true,
+        abbreviation: 'hidden-lesson'
+      }
+    }
+  ],
+  included: [
+    {
+      type: 'translation',
+      id: 't1',
+      relationships: {
+        resource: { data: { id: '1' } },
+        language: { data: { id: '1' } }
+      },
+      attributes: {
+        'translated-name': 'Lesson 1',
+        'translated-tagline': 'tagline'
+      }
+    },
+    {
+      type: 'translation',
+      id: 't2',
+      relationships: {
+        resource: { data: { id: '2' } },
+        language: { data: { id: '2' } }
+      },
+      attributes: {
+        'translated-name': 'Tract 1',
+        'translated-tagline': 'tagline'
+      }
+    },
+    {
+      type: 'translation',
+      id: 't3',
+      relationships: {
+        resource: { data: { id: '3' } },
+        language: { data: { id: '3' } }
+      },
+      attributes: {
+        'translated-name': 'Hidden Lesson',
+        'translated-tagline': 'tagline'
+      }
+    }
+  ]
+};
+
 export const mockSpacer = (height = 100): Spacer => {
   return {
     height,

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,5 +1,11 @@
 import { HttpClientModule } from '@angular/common/http';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+  waitForAsync
+} from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { mockPageComponent } from '../_tests/mocks';
 import { CommonService } from '../services/common.service';
@@ -26,6 +32,33 @@ describe('DashboardComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('prepareLanguageSwitcher() should set availableLangs based on languagesWithLessons and current page', fakeAsync(() => {
+    component['_languagesData'] = [
+      mockPageComponent.languageEnglish,
+      mockPageComponent.languageGerman,
+      mockPageComponent.languageChineseTraditional
+    ];
+    const isLessonsPage = spyOn(component, 'isLessonsPage').and.returnValue(
+      false
+    );
+
+    // No languagesWithLessons, should include all languages
+    component.languagesWithLessons = null;
+    component['prepareLanguageSwitcher']();
+    tick();
+    expect(component.availableLangs.length).toEqual(3);
+
+    component['_languageChanged'].next();
+
+    // On lessons page with languagesWithLessons set, should filter languages
+    component.languagesWithLessons = new Set<string>(['3333']);
+    isLessonsPage.and.returnValue(true);
+    component['prepareLanguageSwitcher']();
+    tick();
+    expect(component.availableLangs.length).toEqual(1);
+    expect(component.availableLangs[0].code).toEqual('zh-Hant');
+  }));
+
   it('setDisplayLanguage() should match case-insensitively and store API correct casing', () => {
     component['_languagesData'] = [
       mockPageComponent.languageChineseTraditional
@@ -34,5 +67,29 @@ describe('DashboardComponent', () => {
     expect(component.dispLanguage).toEqual(3333);
     expect(component.dispLanguageCode).toEqual('zh-Hant');
     expect(component.dispLanguageName).toEqual('Chinese (Traditional)');
+  });
+
+  it('onSelectLanguage() should navigate to correct route based on current page', () => {
+    const navigateSpy = spyOn(component.route, 'navigate');
+    const isToolsPage = spyOn(component, 'isToolsPage').and.returnValue(false);
+    const isLessonsPage = spyOn(component, 'isLessonsPage').and.returnValue(
+      false
+    );
+
+    // On tools page
+    isToolsPage.and.returnValue(true);
+    component.onSelectLanguage('zh-Hant');
+    expect(navigateSpy).toHaveBeenCalledWith(['/', 'zh-Hant', 'tools']);
+
+    // On lessons page
+    isToolsPage.and.returnValue(false);
+    isLessonsPage.and.returnValue(true);
+    component.onSelectLanguage('zh-Hant');
+    expect(navigateSpy).toHaveBeenCalledWith(['/', 'zh-Hant', 'lessons']);
+
+    // On dashboard page
+    isLessonsPage.and.returnValue(false);
+    component.onSelectLanguage('zh-Hant');
+    expect(navigateSpy).toHaveBeenCalledWith(['/', 'zh-Hant']);
   });
 });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -27,6 +27,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private readonly _lessonsRoute = 'lessons';
   tools: Resource[] = [];
   lessons: Resource[] = [];
+  languagesWithLessons: Set<string>;
   englishLangId = 1;
   englishLangCode = 'en';
   englishLangName = 'English';
@@ -82,10 +83,17 @@ export class DashboardComponent implements OnInit, OnDestroy {
         delay(0)
       )
       .subscribe(() => {
-        this.availableLangs = this._languagesData.map((lang) => ({
-          code: lang.attributes.code,
-          name: lang.attributes.name
-        }));
+        this.availableLangs = this._languagesData
+          .filter((lang) => {
+            if (!this.languagesWithLessons || !this.isLessonsPage()) {
+              return true;
+            }
+            return this.languagesWithLessons.has(lang.id);
+          })
+          .map((lang) => ({
+            code: lang.attributes.code,
+            name: lang.attributes.name
+          }));
       });
 
     if (!this._languagesData) {
@@ -158,6 +166,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
             this.tools = data.tools;
             this.lessons = data.lessons;
             this.sectionReady = true;
+            this.languagesWithLessons = data.languagesWithLessons;
+            this._languagesReady.next();
           });
       });
   }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -167,6 +167,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
             this.lessons = data.lessons;
             this.sectionReady = true;
             this.languagesWithLessons = data.languagesWithLessons;
+            // Rebuild availableLangs since languagesWithLessons is set asynchronously after the initial load
             this._languagesReady.next();
           });
       });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -182,7 +182,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.tools = [];
     this.lessons = [];
     this.langSwitchOn = !this.langSwitchOn;
-    this.route.navigate(['/', pLangCode]);
+
+    if (this.isToolsPage()) {
+      this.route.navigate(['/', pLangCode, this._toolsRoute]);
+    } else if (this.isLessonsPage()) {
+      this.route.navigate(['/', pLangCode, this._lessonsRoute]);
+    } else {
+      this.route.navigate(['/', pLangCode]);
+    }
   }
 
   get toolsRoute(): string {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -39,7 +39,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   dispLanguageName: string;
   dispLanguageDirection: string;
   langSwitchOn: boolean;
-  availableLangs: [];
+  availableLangs: { code: string; name: string }[];
   resourceTypes = [ResourceType.Tract, ResourceType.CYOA, ResourceType.Lesson];
 
   constructor(
@@ -83,16 +83,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
         delay(0)
       )
       .subscribe(() => {
+        const shouldFilterLanguages =
+          this.languagesWithLessons && this.isLessonsPage();
+
         this.availableLangs = this._languagesData
           .filter((lang) => {
-            if (!this.languagesWithLessons || !this.isLessonsPage()) {
-              return true;
-            }
-            return this.languagesWithLessons.has(lang.id);
+            return (
+              !shouldFilterLanguages || this.languagesWithLessons.has(lang.id)
+            );
           })
-          .map((lang) => ({
-            code: lang.attributes.code,
-            name: lang.attributes.name
+          .map(({ attributes }) => ({
+            code: attributes.code,
+            name: attributes.name
           }));
       });
 
@@ -194,13 +196,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.lessons = [];
     this.langSwitchOn = !this.langSwitchOn;
 
-    if (this.isToolsPage()) {
-      this.route.navigate(['/', pLangCode, this._toolsRoute]);
-    } else if (this.isLessonsPage()) {
-      this.route.navigate(['/', pLangCode, this._lessonsRoute]);
-    } else {
-      this.route.navigate(['/', pLangCode]);
-    }
+    const segment = this.isToolsPage()
+      ? this._toolsRoute
+      : this.isLessonsPage()
+        ? this._lessonsRoute
+        : null;
+
+    this.route.navigate(segment ? ['/', pLangCode, segment] : ['/', pLangCode]);
   }
 
   get toolsRoute(): string {

--- a/src/app/services/resource.service.spec.ts
+++ b/src/app/services/resource.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientModule } from '@angular/common/http';
 import { TestBed, inject } from '@angular/core/testing';
+import { mockBooksData } from '../_tests/mocks';
 import { ResourceService } from './resource.service';
 
 describe('ResourceService', () => {
@@ -21,78 +22,11 @@ describe('ResourceService', () => {
     it('should process book data correctly and exclude hidden lessons from languagesWithLessons', inject(
       [ResourceService],
       (service: ResourceService) => {
-        const mockBooksData = {
-          data: [
-            {
-              id: '1',
-              attributes: {
-                'resource-type': 'lesson',
-                'attr-hidden': false,
-                abbreviation: 'lesson1'
-              }
-            },
-            {
-              id: '2',
-              attributes: {
-                'resource-type': 'tract',
-                'attr-hidden': false,
-                abbreviation: 'tract1'
-              }
-            },
-            {
-              id: '3',
-              attributes: {
-                'resource-type': 'lesson',
-                'attr-hidden': true,
-                abbreviation: 'hidden-lesson'
-              }
-            }
-          ],
-          included: [
-            {
-              type: 'translation',
-              id: 't1',
-              relationships: {
-                resource: { data: { id: '1' } },
-                language: { data: { id: '1' } }
-              },
-              attributes: {
-                'translated-name': 'Lesson 1',
-                'translated-tagline': 'tagline'
-              }
-            },
-            {
-              type: 'translation',
-              id: 't2',
-              relationships: {
-                resource: { data: { id: '2' } },
-                language: { data: { id: '2' } }
-              },
-              attributes: {
-                'translated-name': 'Tract 1',
-                'translated-tagline': 'tagline'
-              }
-            },
-            {
-              type: 'translation',
-              id: 't3',
-              relationships: {
-                resource: { data: { id: '3' } },
-                language: { data: { id: '3' } }
-              },
-              attributes: {
-                'translated-name': 'Hidden Lesson',
-                'translated-tagline': 'tagline'
-              }
-            }
-          ]
-        };
-
         const result = service['processBookData'](mockBooksData, 1);
 
         expect(result.tools.length).toBe(0);
         expect(result.lessons.length).toBe(1);
-        expect(result.languagesWithLessons.size).toBe(1);
+        expect(result.languagesWithLessons).toHaveSize(1);
         expect(result.languagesWithLessons.has('1')).toBeTrue();
         expect(result.languagesWithLessons.has('2')).toBeFalse();
         expect(result.languagesWithLessons.has('3')).toBeFalse();

--- a/src/app/services/resource.service.spec.ts
+++ b/src/app/services/resource.service.spec.ts
@@ -1,0 +1,102 @@
+import { HttpClientModule } from '@angular/common/http';
+import { TestBed, inject } from '@angular/core/testing';
+import { ResourceService } from './resource.service';
+
+describe('ResourceService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ResourceService],
+      imports: [HttpClientModule]
+    });
+  });
+
+  it('should be created', inject(
+    [ResourceService],
+    (service: ResourceService) => {
+      expect(service).toBeTruthy();
+    }
+  ));
+
+  describe('processBookData', () => {
+    it('should process book data correctly and exclude hidden lessons from languagesWithLessons', inject(
+      [ResourceService],
+      (service: ResourceService) => {
+        const mockBooksData = {
+          data: [
+            {
+              id: '1',
+              attributes: {
+                'resource-type': 'lesson',
+                'attr-hidden': false,
+                abbreviation: 'lesson1'
+              }
+            },
+            {
+              id: '2',
+              attributes: {
+                'resource-type': 'tract',
+                'attr-hidden': false,
+                abbreviation: 'tract1'
+              }
+            },
+            {
+              id: '3',
+              attributes: {
+                'resource-type': 'lesson',
+                'attr-hidden': true,
+                abbreviation: 'hidden-lesson'
+              }
+            }
+          ],
+          included: [
+            {
+              type: 'translation',
+              id: 't1',
+              relationships: {
+                resource: { data: { id: '1' } },
+                language: { data: { id: '1' } }
+              },
+              attributes: {
+                'translated-name': 'Lesson 1',
+                'translated-tagline': 'tagline'
+              }
+            },
+            {
+              type: 'translation',
+              id: 't2',
+              relationships: {
+                resource: { data: { id: '2' } },
+                language: { data: { id: '2' } }
+              },
+              attributes: {
+                'translated-name': 'Tract 1',
+                'translated-tagline': 'tagline'
+              }
+            },
+            {
+              type: 'translation',
+              id: 't3',
+              relationships: {
+                resource: { data: { id: '3' } },
+                language: { data: { id: '3' } }
+              },
+              attributes: {
+                'translated-name': 'Hidden Lesson',
+                'translated-tagline': 'tagline'
+              }
+            }
+          ]
+        };
+
+        const result = service['processBookData'](mockBooksData, 1);
+
+        expect(result.tools.length).toBe(0);
+        expect(result.lessons.length).toBe(1);
+        expect(result.languagesWithLessons.size).toBe(1);
+        expect(result.languagesWithLessons.has('1')).toBeTrue();
+        expect(result.languagesWithLessons.has('2')).toBeFalse();
+        expect(result.languagesWithLessons.has('3')).toBeFalse();
+      }
+    ));
+  });
+});

--- a/src/app/services/resource.service.ts
+++ b/src/app/services/resource.service.ts
@@ -56,7 +56,8 @@ export class ResourceService {
       booksData.data
         .filter(
           (resource: any) =>
-            resource.attributes['resource-type'] === ResourceType.Lesson
+            resource.attributes['resource-type'] === ResourceType.Lesson &&
+            !resource.attributes['attr-hidden']
         )
         .map((resource) => resource.id)
     );

--- a/src/app/services/resource.service.ts
+++ b/src/app/services/resource.service.ts
@@ -16,6 +16,7 @@ export interface Resource {
 export interface DashboardData {
   tools: Resource[];
   lessons: Resource[];
+  languagesWithLessons: Set<string>;
 }
 
 @Injectable({
@@ -49,6 +50,24 @@ export class ResourceService {
       (included: any) =>
         included.type === 'translation' &&
         Number(included.relationships.language.data.id) === languageId
+    );
+
+    const lessonResourceIds = new Set<string>(
+      booksData.data
+        .filter(
+          (resource: any) =>
+            resource.attributes['resource-type'] === ResourceType.Lesson
+        )
+        .map((resource) => resource.id)
+    );
+    const languagesWithLessons = new Set<string>(
+      booksData.included
+        .filter(
+          (included: any) =>
+            included.type === 'translation' &&
+            lessonResourceIds.has(included.relationships.resource.data.id)
+        )
+        .map((translation: any) => translation.relationships.language.data.id)
     );
 
     const tools: Resource[] = [];
@@ -121,6 +140,6 @@ export class ResourceService {
         }
       });
 
-    return { tools, lessons };
+    return { tools, lessons, languagesWithLessons };
   }
 }


### PR DESCRIPTION
When a user is on the tools or lessons page and desires to switch the language, it will route them to the dashboard. Instead, we want the user to remain on these pages.

Also, when on the lessons page, we only want to show the languages that have at least one lesson. 

Jira ticket: [GT-2868](https://jira.cru.org/browse/GT-2868)

### Testing
Routing Test:
- Go to `/en/lessons`
- Click on language selector and select a different language
- Ensure user remains on lessons page

Filtered Languages Test:
- Go to `/en/lessons`
- Click on language selector and select a different language
- Verify only languages with at least one lesson is present