### PR TITLE
GT-2790 Add card style for multiselect element

### DIFF
--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -17,6 +17,7 @@ import {
   Modal,
   Multiselect,
   MultiselectOption,
+  MultiselectOptionStyle,
   Paragraph,
   Resource,
   Spacer,
@@ -344,13 +345,13 @@ export const mockModal = (title: string, listeners): Modal => {
 };
 
 export const mockMultiselectOption = (
-  initialSelectedValue
+  initialSelectedValue,
+  style: org.cru.godtools.shared.tool.parser.model.Multiselect.Option.Style = MultiselectOptionStyle.CARD
 ): MultiselectOption => {
   let selectedValue = initialSelectedValue;
   return {
     id: null,
-    style:
-      org.cru.godtools.shared.tool.parser.model.Multiselect.Option.Style.CARD,
+    style,
     backgroundColor: '#000000',
     selectedColor: '#ffffff',
     multiselect: null,

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.css
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.css
@@ -17,3 +17,8 @@
   box-shadow: inset 0px 0px 7px 2px rgba(0, 0, 0, 8%);
   opacity: 1;
 }
+
+.multiselect-option.card {
+  border-radius: 8px;
+  box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 8%);
+}

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.css
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.css
@@ -12,13 +12,13 @@
   }
 }
 
+.multiselect-option.card {
+  border-radius: 8px;
+  box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 8%);
+}
+
 .multiselect-option.selected {
   border-radius: 8px;
   box-shadow: inset 0px 0px 7px 2px rgba(0, 0, 0, 8%);
   opacity: 1;
-}
-
-.multiselect-option.card {
-  border-radius: 8px;
-  box-shadow: 0px 0px 7px 2px rgba(0, 0, 0, 8%);
 }

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.html
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.html
@@ -4,7 +4,7 @@
     'background-color': selected ? option.selectedColor : option.backgroundColor
   }"
   class="multiselect-option"
-  [ngClass]="{ selected: selected }"
+  [ngClass]="{ selected: selected, card: isCard }"
   (click)="onClick()"
 >
   <app-content-repeater [items]="contents"></app-content-repeater>

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.spec.ts
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.spec.ts
@@ -1,5 +1,6 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MultiselectOptionStyle } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { mockMultiselectOption } from '../../../_tests/mocks';
 import { ContentMultiselectOptionComponent } from './content-multiselect-option.component';
 
@@ -34,5 +35,39 @@ describe('ContentMultiselectOptionComponent', () => {
     expect(component.option.isSelected(null)).toEqual(true);
     component.onClick();
     expect(component.option.isSelected(null)).toEqual(false);
+  });
+
+  it('should render card class when the option style is card', async () => {
+    const cardOption = mockMultiselectOption(
+      false,
+      MultiselectOptionStyle.CARD
+    );
+    component.item = cardOption;
+    component.ngOnChanges({
+      item: new SimpleChange(null, cardOption, true)
+    });
+    fixture.detectChanges();
+
+    const optionElement: HTMLElement = fixture.nativeElement.querySelector(
+      '.multiselect-option'
+    );
+    expect(optionElement.classList.contains('card')).toBeTrue();
+  });
+
+  it('should not render card class when the option style is flat', async () => {
+    const flatOption = mockMultiselectOption(
+      false,
+      MultiselectOptionStyle.FLAT
+    );
+    component.item = flatOption;
+    component.ngOnChanges({
+      item: new SimpleChange(null, flatOption, true)
+    });
+    fixture.detectChanges();
+
+    const optionElement: HTMLElement = fixture.nativeElement.querySelector(
+      '.multiselect-option'
+    );
+    expect(optionElement.classList.contains('card')).toBeFalse();
   });
 });

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.ts
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.ts
@@ -5,11 +5,11 @@ import {
   OnDestroy,
   SimpleChanges
 } from '@angular/core';
-import { org } from '@cruglobal/godtools-shared';
 import {
   Content,
   FlowWatcher,
-  MultiselectOption
+  MultiselectOption,
+  MultiselectOptionStyle
 } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { PageService } from '../../service/page-service.service';
 
@@ -59,10 +59,7 @@ export class ContentMultiselectOptionComponent implements OnChanges, OnDestroy {
   }
 
   get isCard(): boolean {
-    return (
-      this.option.style ===
-      org.cru.godtools.shared.tool.parser.model.Multiselect.Option.Style.CARD
-    );
+    return this.option.style === MultiselectOptionStyle.CARD;
   }
 
   private init(): void {

--- a/src/app/page/component/content-multiselect-option/content-multiselect-option.component.ts
+++ b/src/app/page/component/content-multiselect-option/content-multiselect-option.component.ts
@@ -5,6 +5,7 @@ import {
   OnDestroy,
   SimpleChanges
 } from '@angular/core';
+import { org } from '@cruglobal/godtools-shared';
 import {
   Content,
   FlowWatcher,
@@ -55,6 +56,13 @@ export class ContentMultiselectOptionComponent implements OnChanges, OnDestroy {
 
   onClick() {
     this.option.toggleSelected(this.state);
+  }
+
+  get isCard(): boolean {
+    return (
+      this.option.style ===
+      org.cru.godtools.shared.tool.parser.model.Multiselect.Option.Style.CARD
+    );
   }
 
   private init(): void {

--- a/src/app/page/component/content-multiselect/content-multiselect.component.css
+++ b/src/app/page/component/content-multiselect/content-multiselect.component.css
@@ -8,7 +8,7 @@
   margin: 0;
 }
 
-.multiselect app-content-multiselect-option {
+.multiselect app-content-multiselect-option:has(.multiselect-option.card) {
   margin-top: 5px;
 }
 

--- a/src/app/page/component/content-multiselect/content-multiselect.component.css
+++ b/src/app/page/component/content-multiselect/content-multiselect.component.css
@@ -8,6 +8,10 @@
   margin: 0;
 }
 
+.multiselect app-content-multiselect-option {
+  margin-top: 5px;
+}
+
 .multiselect[data-columns='1'] app-content-multiselect-option {
   flex: 0 1 100%;
 }

--- a/src/app/services/xml-parser-service/xml-parser.service.ts
+++ b/src/app/services/xml-parser-service/xml-parser.service.ts
@@ -77,6 +77,9 @@ export const ParserConfig = org.cru.godtools.shared.tool.parser.ParserConfig;
 export const ManifestParser = manifestParser;
 export const State = org.cru.godtools.shared.renderer.state.State;
 
+export const MultiselectOptionStyle =
+  org.cru.godtools.shared.tool.parser.model.Multiselect.Option.Style;
+
 export const ContentParser = (content: any): string => {
   if (content instanceof org.cru.godtools.shared.tool.parser.model.Image) {
     // console.log('CONTENT: Image');


### PR DESCRIPTION
Add card styling on top of the already supported flat style for multiselect element. 

https://github.com/CruGlobal/mobile-content-api/blob/3bbac5c1a1b7a123e44394268713f94d2d996d94/public/xmlns/content.xsd#L989-L994 

Jira ticket: [GT-2790](https://jira.cru.org/browse/GT-2790)

**Before:**
<img width="551" height="717" alt="Screenshot 2026-05-05 at 10 39 09 AM" src="https://github.com/user-attachments/assets/6f0cb6ff-b3a7-4c55-b3b6-c7a4802c1b32" />

**After:**
<img width="668" height="747" alt="Screenshot 2026-05-05 at 10 39 31 AM" src="https://github.com/user-attachments/assets/92409011-4c70-4828-9556-d4051075711d" />

### Testing
- Go to `/en/lesson/lessondemogospel/6`
- Check that the new card style renders