### PR TITLE
GT-2035 Fully support clickable interface

### DIFF
--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -152,7 +152,7 @@ export const mockAnimation = (
     playListeners: [createEventId(`${event}-play-listener`)],
     stopListeners: [createEventId(`${event}-stop-listener`)],
     isClickable: !!url || !!event,
-    events: [createEventId(event)],
+    events: event ? [createEventId(event)] : [],
     _events: null,
     _playListeners: null,
     _stopListeners: null,
@@ -184,10 +184,12 @@ export const mockLink = (url: string, text: string): Link => {
     url,
     text: createText(text),
     isClickable: true,
-    events: [
-      createEventId('followup-testing-event'),
-      createEventId('send', 'followup')
-    ],
+    events: !url
+      ? [
+          createEventId('followup-testing-event'),
+          createEventId('send', 'followup')
+        ]
+      : [],
     ...standardTypeValues()
   };
 };
@@ -398,15 +400,16 @@ export const mockFlow = (): Flow => {
   };
 };
 
-export const mockCard = (isClickable): Card => {
+export const mockCard = (isClickable: boolean, isUrl: boolean): Card => {
   return {
     backgroundColor: '#000000',
-    url: isClickable ? 'URL' : null,
+    url: isUrl ? 'URL' : null,
     content: mockContent(),
     isClickable,
-    events: isClickable
-      ? [createEventId('event-1', 'namespace'), createEventId('event-2')]
-      : [],
+    events:
+      isClickable && !isUrl
+        ? [createEventId('event-1', 'namespace'), createEventId('event-2')]
+        : [],
     ...standardTypeValues()
   };
 };

--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -179,12 +179,16 @@ export const mockInput = (
   };
 };
 
-export const mockLink = (url: string, text: string): Link => {
+export const mockLink = (
+  url: string,
+  text: string,
+  hasEvents: boolean = false
+): Link => {
   return {
     url,
     text: createText(text),
     isClickable: true,
-    events: !url
+    events: hasEvents
       ? [
           createEventId('followup-testing-event'),
           createEventId('send', 'followup')
@@ -400,16 +404,15 @@ export const mockFlow = (): Flow => {
   };
 };
 
-export const mockCard = (isClickable: boolean, isUrl: boolean): Card => {
+export const mockCard = (hasEvents: boolean, hasUrl: boolean): Card => {
   return {
     backgroundColor: '#000000',
-    url: isUrl ? 'URL' : null,
+    url: hasUrl ? 'URL' : null,
     content: mockContent(),
-    isClickable,
-    events:
-      isClickable && !isUrl
-        ? [createEventId('event-1', 'namespace'), createEventId('event-2')]
-        : [],
+    isClickable: hasEvents || hasUrl,
+    events: hasEvents
+      ? [createEventId('event-1', 'namespace'), createEventId('event-2')]
+      : [],
     ...standardTypeValues()
   };
 };

--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -179,15 +179,11 @@ export const mockInput = (
   };
 };
 
-export const mockLink = (
-  url: string,
-  text: string,
-  isClickable: boolean
-): Link => {
+export const mockLink = (url: string, text: string): Link => {
   return {
     url,
     text: createText(text),
-    isClickable,
+    isClickable: true,
     events: [
       createEventId('followup-testing-event'),
       createEventId('send', 'followup')
@@ -405,7 +401,7 @@ export const mockFlow = (): Flow => {
 export const mockCard = (isClickable): Card => {
   return {
     backgroundColor: '#000000',
-    url: 'URL',
+    url: isClickable ? 'URL' : null,
     content: mockContent(),
     isClickable,
     events: isClickable

--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -103,7 +103,7 @@ const createButton = (text: string, url: string, event: string): Button => {
     iconSize: 1,
     text: createText('Button Text'),
     events: event ? [createEventId(event)] : [],
-    isClickable: true,
+    isClickable: !!url || !!event,
     ...standardTypeValues()
   };
 };
@@ -126,14 +126,14 @@ export const mockButton = (
 export const mockImage = (
   name: string,
   url: string,
-  event: string = ''
+  event: string = null
 ): Image => {
   return {
     url,
     resource: createResource(name, url),
     gravity: null,
     width: null,
-    isClickable: null,
+    isClickable: !!url || !!event,
     events: event ? [createEventId(event)] : [],
     ...standardTypeValues()
   };
@@ -151,7 +151,7 @@ export const mockAnimation = (
     autoPlay: true,
     playListeners: [createEventId(`${event}-play-listener`)],
     stopListeners: [createEventId(`${event}-stop-listener`)],
-    isClickable: true,
+    isClickable: !!url || !!event,
     events: [createEventId(event)],
     _events: null,
     _playListeners: null,

--- a/src/app/page/component/content-animation/content-animation.component.html
+++ b/src/app/page/component/content-animation/content-animation.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="ready && anmResource">
   <div class="animation-container">
     <ng-lottie
-      (click)="onAnimationClick()"
+      (click)="onClick()"
       [options]="lottieOptions"
       (animationCreated)="onAnimationCreated($event)"
     ></ng-lottie>

--- a/src/app/page/component/content-animation/content-animation.component.html
+++ b/src/app/page/component/content-animation/content-animation.component.html
@@ -1,9 +1,23 @@
 <ng-container *ngIf="ready && anmResource">
   <div class="animation-container">
-    <ng-lottie
+    <a
+      *ngIf="animation.url; else animationTemplate"
+      [href]="animation.url"
+      target="_blank"
+      rel="noopener noreferrer"
       (click)="onClick()"
-      [options]="lottieOptions"
-      (animationCreated)="onAnimationCreated($event)"
-    ></ng-lottie>
+    >
+      <ng-lottie
+        [options]="lottieOptions"
+        (animationCreated)="onAnimationCreated($event)"
+      ></ng-lottie>
+    </a>
+    <ng-template #animationTemplate>
+      <ng-lottie
+        (click)="onClick()"
+        [options]="lottieOptions"
+        (animationCreated)="onAnimationCreated($event)"
+      ></ng-lottie>
+    </ng-template>
   </div>
 </ng-container>

--- a/src/app/page/component/content-animation/content-animation.component.spec.ts
+++ b/src/app/page/component/content-animation/content-animation.component.spec.ts
@@ -10,6 +10,8 @@ describe('ContentAnimationComponent', () => {
   const fileName = 'the_four_animation.json';
   const filePath = `/some-folder/${fileName}`;
   const animation = mockAnimation(fileName, filePath, 'event');
+  const animationWithUrl = mockAnimation(fileName, filePath, null);
+  const animationWithEvents = mockAnimation(fileName, null, 'event');
   const fileNameNotAdded = 'name-of-file-not-added.png';
   const filePathNotAdded = `/some-folder/${fileName}`;
   const animationNoNameNotAdded = mockAnimation(
@@ -54,9 +56,11 @@ describe('ContentAnimationComponent', () => {
     expect(pageService.findAttachment).toHaveBeenCalledWith(fileNameNotAdded);
   });
 
-  it('fires events and opens url when both are configured', () => {
-    component.item = animation;
-    component.ngOnChanges({ item: new SimpleChange(null, animation, true) });
+  it('fires events only when clicked on with events', () => {
+    component.item = animationWithEvents;
+    component.ngOnChanges({
+      item: new SimpleChange(null, animationWithEvents, true)
+    });
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
@@ -65,6 +69,22 @@ describe('ContentAnimationComponent', () => {
     component.onClick();
 
     expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('opens urls only when clicked on with url', () => {
+    component.item = animationWithUrl;
+    component.ngOnChanges({
+      item: new SimpleChange(null, animationWithUrl, true)
+    });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalledWith(filePath, '_blank');
   });
 });

--- a/src/app/page/component/content-animation/content-animation.component.spec.ts
+++ b/src/app/page/component/content-animation/content-animation.component.spec.ts
@@ -44,7 +44,6 @@ describe('ContentAnimationComponent', () => {
       loop: true,
       autoplay: true
     });
-    expect(component.hasEvents).toBeTrue();
   });
 
   it('Find animation from pageService if not in pageService', () => {
@@ -53,5 +52,19 @@ describe('ContentAnimationComponent', () => {
       item: new SimpleChange(null, animationNoNameNotAdded, true)
     });
     expect(pageService.findAttachment).toHaveBeenCalledWith(fileNameNotAdded);
+  });
+
+  it('fires events and opens url when both are configured', () => {
+    component.item = animation;
+    component.ngOnChanges({ item: new SimpleChange(null, animation, true) });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(filePath, '_blank');
   });
 });

--- a/src/app/page/component/content-animation/content-animation.component.spec.ts
+++ b/src/app/page/component/content-animation/content-animation.component.spec.ts
@@ -1,4 +1,4 @@
-import { SimpleChange } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { mockAnimation } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
@@ -25,7 +25,8 @@ describe('ContentAnimationComponent', () => {
     pageService = new PageService();
     TestBed.configureTestingModule({
       declarations: [ContentAnimationComponent],
-      providers: [{ provide: PageService, useValue: pageService }]
+      providers: [{ provide: PageService, useValue: pageService }],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
     fixture = TestBed.createComponent(ContentAnimationComponent);
     component = fixture.componentInstance;
@@ -61,15 +62,15 @@ describe('ContentAnimationComponent', () => {
     component.ngOnChanges({
       item: new SimpleChange(null, animationWithEvents, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
 
     component.onClick();
 
     expect(pageService.formAction).toHaveBeenCalled();
-    expect(window.open).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.querySelector('a')).toBeNull();
   });
 
   it('opens urls only when clicked on with url', () => {
@@ -77,14 +78,37 @@ describe('ContentAnimationComponent', () => {
     component.ngOnChanges({
       item: new SimpleChange(null, animationWithUrl, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(animationWithUrl.url);
+    expect(anchor.getAttribute('target')).toBe('_blank');
 
     component.onClick();
 
     expect(pageService.formAction).not.toHaveBeenCalled();
-    expect(window.open).toHaveBeenCalledWith(filePath, '_blank');
+  });
+
+  it('fires events and opens url when both are present', () => {
+    component.item = animation;
+    component.ngOnChanges({
+      item: new SimpleChange(null, animation, true)
+    });
+    fixture.detectChanges();
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(animation.url);
+    expect(anchor.getAttribute('target')).toBe('_blank');
+
+    component.onClick();
+    expect(pageService.formAction).toHaveBeenCalledWith('event');
   });
 });

--- a/src/app/page/component/content-animation/content-animation.component.ts
+++ b/src/app/page/component/content-animation/content-animation.component.ts
@@ -57,7 +57,7 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
   }
 
   onClick(): void {
-    this.pageService.handleClickable(this.animation.events, this.animation.url);
+    this.pageService.handleClickable(this.animation.events);
   }
 
   onAnimationCreated(anim: AnimationItem): void {

--- a/src/app/page/component/content-animation/content-animation.component.ts
+++ b/src/app/page/component/content-animation/content-animation.component.ts
@@ -25,7 +25,6 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
   ready: boolean;
   anmResource: string;
   anmViewItem: AnimationItem;
-  hasEvents: boolean;
   dir$: Observable<string>;
   lottieOptions: AnimationOptions;
 
@@ -57,7 +56,7 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
     }
   }
 
-  onAnimationClick(): void {
+  onClick(): void {
     this.pageService.handleClickable(this.animation.events, this.animation.url);
   }
 
@@ -88,8 +87,6 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
         autoplay: !!this.animation.autoPlay
       };
     }
-
-    this.hasEvents = !!this.animation.events;
 
     if (!!this.animation.playListeners || !!this.animation.stopListeners) {
       this.awaitAnimEvent();

--- a/src/app/page/component/content-animation/content-animation.component.ts
+++ b/src/app/page/component/content-animation/content-animation.component.ts
@@ -58,16 +58,7 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
   }
 
   onAnimationClick(): void {
-    if (this.animation.events) {
-      let action = '';
-      this.animation.events.forEach((event, idx) => {
-        const value = event?.namespace
-          ? `${event.namespace}:${event.name}`
-          : event.name;
-        action += idx ? ` ${value}` : value;
-      });
-      this.pageService.formAction(action);
-    }
+    this.pageService.handleClickable(this.animation.events, this.animation.url);
   }
 
   onAnimationCreated(anim: AnimationItem): void {

--- a/src/app/page/component/content-button/content-button.component.html
+++ b/src/app/page/component/content-button/content-button.component.html
@@ -1,11 +1,30 @@
 <ng-container *ngIf="ready">
   <div class="mw568 buttonContent tc" dir="{{ dir$ | async }}">
     <a
+      *ngIf="button.url; else buttonTemplate"
       class="button"
-      [ngStyle]="{ 'background-color': buttonBgColor, color: buttonTextColor }"
+      [href]="button.url"
+      [ngStyle]="{
+        'background-color': buttonBgColor,
+        color: buttonTextColor
+      }"
+      target="_blank"
+      rel="noopener noreferrer"
       (click)="onClick()"
-      href="javascript:void(0)"
       >{{ buttonText }}</a
     >
+    <ng-template #buttonTemplate>
+      <button
+        type="button"
+        class="button"
+        [ngStyle]="{
+          'background-color': buttonBgColor,
+          color: buttonTextColor
+        }"
+        (click)="onClick()"
+      >
+        {{ buttonText }}
+      </button>
+    </ng-template>
   </div>
 </ng-container>

--- a/src/app/page/component/content-button/content-button.component.html
+++ b/src/app/page/component/content-button/content-button.component.html
@@ -1,15 +1,6 @@
 <ng-container *ngIf="ready">
   <div class="mw568 buttonContent tc" dir="{{ dir$ | async }}">
     <a
-      *ngIf="type === 'url'"
-      [href]="url"
-      [ngStyle]="{ 'background-color': buttonBgColor, color: buttonTextColor }"
-      class="button"
-      target="_blank"
-      >{{ buttonText }}</a
-    >
-    <a
-      *ngIf="type === 'event'"
       class="button"
       [ngStyle]="{ 'background-color': buttonBgColor, color: buttonTextColor }"
       (click)="formAction()"

--- a/src/app/page/component/content-button/content-button.component.html
+++ b/src/app/page/component/content-button/content-button.component.html
@@ -3,7 +3,7 @@
     <a
       class="button"
       [ngStyle]="{ 'background-color': buttonBgColor, color: buttonTextColor }"
-      (click)="formAction()"
+      (click)="onClick()"
       href="javascript:void(0)"
       >{{ buttonText }}</a
     >

--- a/src/app/page/component/content-button/content-button.component.spec.ts
+++ b/src/app/page/component/content-button/content-button.component.spec.ts
@@ -10,7 +10,6 @@ describe('ContentButtonComponent', () => {
   const buttonText = 'Button Text';
   const buttonUrl = 'www.some-url-path.com';
   const buttonEvent = 'open-test-modal';
-  const button = mockButton('text', 'https://example.com', 'btnEvent');
   const mockEventButton = mockButton(buttonText, '', buttonEvent);
   const mockUrlButton = mockButton(buttonText, buttonUrl, '');
 
@@ -42,7 +41,7 @@ describe('ContentButtonComponent', () => {
     expect(component.buttonText).toBe(buttonText);
   });
 
-  it('Test events', () => {
+  it('fires events only when clicked on with events', () => {
     component.item = mockEventButton;
     component.ngOnChanges({
       item: new SimpleChange(null, mockEventButton, true)
@@ -50,15 +49,18 @@ describe('ContentButtonComponent', () => {
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
 
     component.onClick();
-
     expect(pageService.formAction).toHaveBeenCalledWith(buttonEvent);
+    expect(window.open).not.toHaveBeenCalled();
   });
 
-  it('fires events and opens url when both are configured', () => {
-    component.item = button;
-    component.ngOnChanges({ item: new SimpleChange(null, button, true) });
+  it('opens urls only when clicked on with url', () => {
+    component.item = mockUrlButton;
+    component.ngOnChanges({
+      item: new SimpleChange(null, mockUrlButton, true)
+    });
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
@@ -66,7 +68,7 @@ describe('ContentButtonComponent', () => {
 
     component.onClick();
 
-    expect(pageService.formAction).toHaveBeenCalled();
-    expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank');
+    expect(pageService.formAction).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith('www.some-url-path.com', '_blank');
   });
 });

--- a/src/app/page/component/content-button/content-button.component.spec.ts
+++ b/src/app/page/component/content-button/content-button.component.spec.ts
@@ -12,6 +12,11 @@ describe('ContentButtonComponent', () => {
   const buttonEvent = 'open-test-modal';
   const mockEventButton = mockButton(buttonText, '', buttonEvent);
   const mockUrlButton = mockButton(buttonText, buttonUrl, '');
+  const mockButtonWithEventAndUrl = mockButton(
+    buttonText,
+    buttonUrl,
+    buttonEvent
+  );
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -46,14 +51,15 @@ describe('ContentButtonComponent', () => {
     component.ngOnChanges({
       item: new SimpleChange(null, mockEventButton, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
 
     component.onClick();
     expect(pageService.formAction).toHaveBeenCalledWith(buttonEvent);
-    expect(window.open).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.querySelector('a')).toBeNull();
+    expect(fixture.nativeElement.querySelector('button')).toBeTruthy();
   });
 
   it('opens urls only when clicked on with url', () => {
@@ -61,14 +67,37 @@ describe('ContentButtonComponent', () => {
     component.ngOnChanges({
       item: new SimpleChange(null, mockUrlButton, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(buttonUrl);
+    expect(anchor.getAttribute('target')).toBe('_blank');
 
     component.onClick();
-
     expect(pageService.formAction).not.toHaveBeenCalled();
-    expect(window.open).toHaveBeenCalledWith('www.some-url-path.com', '_blank');
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+
+  it('fires events and opens url when both are present', () => {
+    component.item = mockButtonWithEventAndUrl;
+    component.ngOnChanges({
+      item: new SimpleChange(null, mockButtonWithEventAndUrl, true)
+    });
+    fixture.detectChanges();
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(buttonUrl);
+    expect(anchor.getAttribute('target')).toBe('_blank');
+
+    component.onClick();
+    expect(pageService.formAction).toHaveBeenCalledWith(buttonEvent);
   });
 });

--- a/src/app/page/component/content-button/content-button.component.spec.ts
+++ b/src/app/page/component/content-button/content-button.component.spec.ts
@@ -30,7 +30,6 @@ describe('ContentButtonComponent', () => {
     });
     expect(component).toBeTruthy();
     expect(component.buttonText).toBe(buttonText);
-    expect(component.type).toBe('event');
     expect(component.events.length).toBe(1);
   });
 
@@ -41,7 +40,6 @@ describe('ContentButtonComponent', () => {
     });
     expect(component).toBeTruthy();
     expect(component.buttonText).toBe(buttonText);
-    expect(component.type).toBe('url');
   });
 
   it('Test events', () => {

--- a/src/app/page/component/content-button/content-button.component.spec.ts
+++ b/src/app/page/component/content-button/content-button.component.spec.ts
@@ -10,6 +10,7 @@ describe('ContentButtonComponent', () => {
   const buttonText = 'Button Text';
   const buttonUrl = 'www.some-url-path.com';
   const buttonEvent = 'open-test-modal';
+  const button = mockButton('text', 'https://example.com', 'btnEvent');
   const mockEventButton = mockButton(buttonText, '', buttonEvent);
   const mockUrlButton = mockButton(buttonText, buttonUrl, '');
 
@@ -30,7 +31,6 @@ describe('ContentButtonComponent', () => {
     });
     expect(component).toBeTruthy();
     expect(component.buttonText).toBe(buttonText);
-    expect(component.events.length).toBe(1);
   });
 
   it('URL Button, Added http set URL', () => {
@@ -51,8 +51,22 @@ describe('ContentButtonComponent', () => {
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
 
-    component.formAction();
+    component.onClick();
 
     expect(pageService.formAction).toHaveBeenCalledWith(buttonEvent);
+  });
+
+  it('fires events and opens url when both are configured', () => {
+    component.item = button;
+    component.ngOnChanges({ item: new SimpleChange(null, button, true) });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank');
   });
 });

--- a/src/app/page/component/content-button/content-button.component.ts
+++ b/src/app/page/component/content-button/content-button.component.ts
@@ -1,9 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
-import {
-  Button,
-  EventId
-} from 'src/app/services/xml-parser-service/xml-parser.service';
+import { Button } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
@@ -18,8 +15,6 @@ export class ContentButtonComponent implements OnChanges {
   text: any;
   ready: boolean;
   buttonText: string;
-  events: EventId[];
-  url: string;
   buttonTextColor: string;
   buttonBgColor: string;
   dir$: Observable<string>;
@@ -39,8 +34,6 @@ export class ContentButtonComponent implements OnChanges {
             ) {
               this.ready = false;
               this.buttonText = '';
-              this.events = [] as EventId[];
-              this.url = '';
               this.text = null;
               this.button = this.item;
               this.buttonTextColor = '';
@@ -53,8 +46,8 @@ export class ContentButtonComponent implements OnChanges {
     }
   }
 
-  formAction(): void {
-    this.pageService.handleClickable(this.events, this.url);
+  onClick(): void {
+    this.pageService.handleClickable(this.button.events, this.button.url);
   }
 
   private init(): void {
@@ -66,8 +59,6 @@ export class ContentButtonComponent implements OnChanges {
       this.buttonText = this.text?.text || '';
     }
 
-    this.url = this.button.url;
-    this.events = this.button.events;
     this.ready = true;
   }
 }

--- a/src/app/page/component/content-button/content-button.component.ts
+++ b/src/app/page/component/content-button/content-button.component.ts
@@ -47,7 +47,7 @@ export class ContentButtonComponent implements OnChanges {
   }
 
   onClick(): void {
-    this.pageService.handleClickable(this.button.events, this.button.url);
+    this.pageService.handleClickable(this.button.events);
   }
 
   private init(): void {

--- a/src/app/page/component/content-button/content-button.component.ts
+++ b/src/app/page/component/content-button/content-button.component.ts
@@ -4,7 +4,6 @@ import {
   Button,
   EventId
 } from 'src/app/services/xml-parser-service/xml-parser.service';
-import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
@@ -19,7 +18,6 @@ export class ContentButtonComponent implements OnChanges {
   text: any;
   ready: boolean;
   buttonText: string;
-  type: string;
   events: EventId[];
   url: string;
   buttonTextColor: string;
@@ -41,7 +39,6 @@ export class ContentButtonComponent implements OnChanges {
             ) {
               this.ready = false;
               this.buttonText = '';
-              this.type = '';
               this.events = [] as EventId[];
               this.url = '';
               this.text = null;
@@ -57,18 +54,16 @@ export class ContentButtonComponent implements OnChanges {
   }
 
   formAction(): void {
-    if (this.events && this.type === 'event') {
-      // Each event can resolve into an array of events, so combine them into a single array.
-      // This is necessary to support complex form actions with 'state' in the EventId.
-      // (`Array.flatMap` isn't supported yet, so we use `[].concat(...arrays)`)
-      const resolvedEvents = [].concat(
-        ...this.events.map((event) =>
-          event.resolve(this.pageService.parserState()).asJsReadonlyArrayView()
-        )
-      );
+    // Each event can resolve into an array of events, so combine them into a single array.
+    // This is necessary to support complex form actions with 'state' in the EventId.
+    // (`Array.flatMap` isn't supported yet, so we usåe `[].concat(...arrays)`)
+    const resolvedEvents = [].concat(
+      ...this.events.map((event) =>
+        event.resolve(this.pageService.parserState()).asJsReadonlyArrayView()
+      )
+    );
 
-      this.pageService.formAction(formatEvents(resolvedEvents));
-    }
+    this.pageService.handleClickable(resolvedEvents, this.url);
   }
 
   private init(): void {
@@ -79,17 +74,9 @@ export class ContentButtonComponent implements OnChanges {
       this.text = this.button.text;
       this.buttonText = this.text?.text || '';
     }
-    const isUrlType = !!this.button.url;
-    const isEventType = !!this.button.events?.length;
 
-    if (isUrlType) {
-      this.type = 'url';
-      this.url = this.button.url;
-    }
-    if (isEventType) {
-      this.type = 'event';
-      this.events = this.button.events;
-    }
+    this.url = this.button.url;
+    this.events = this.button.events;
     this.ready = true;
   }
 }

--- a/src/app/page/component/content-button/content-button.component.ts
+++ b/src/app/page/component/content-button/content-button.component.ts
@@ -54,16 +54,7 @@ export class ContentButtonComponent implements OnChanges {
   }
 
   formAction(): void {
-    // Each event can resolve into an array of events, so combine them into a single array.
-    // This is necessary to support complex form actions with 'state' in the EventId.
-    // (`Array.flatMap` isn't supported yet, so we usåe `[].concat(...arrays)`)
-    const resolvedEvents = [].concat(
-      ...this.events.map((event) =>
-        event.resolve(this.pageService.parserState()).asJsReadonlyArrayView()
-      )
-    );
-
-    this.pageService.handleClickable(resolvedEvents, this.url);
+    this.pageService.handleClickable(this.events, this.url);
   }
 
   private init(): void {

--- a/src/app/page/component/content-card/content-card.component.html
+++ b/src/app/page/component/content-card/content-card.component.html
@@ -7,11 +7,24 @@
     <app-content-repeater [items]="contents"></app-content-repeater>
   </div>
   <a
-    *ngIf="card.isClickable"
+    *ngIf="card.isClickable && card.url; else cardTemplate"
     class="card clickable"
+    [href]="card.url"
+    target="_blank"
+    rel="noopener noreferrer"
     (click)="onClick()"
     [ngStyle]="{ 'background-color': background }"
   >
     <app-content-repeater [items]="contents"></app-content-repeater>
   </a>
+  <ng-template #cardTemplate>
+    <a
+      *ngIf="card.isClickable"
+      class="card clickable"
+      (click)="onClick()"
+      [ngStyle]="{ 'background-color': background }"
+    >
+      <app-content-repeater [items]="contents"></app-content-repeater>
+    </a>
+  </ng-template>
 </ng-container>

--- a/src/app/page/component/content-card/content-card.component.html
+++ b/src/app/page/component/content-card/content-card.component.html
@@ -9,7 +9,7 @@
   <a
     *ngIf="card.isClickable"
     class="card clickable"
-    (click)="eventClick()"
+    (click)="onClick()"
     [ngStyle]="{ 'background-color': background }"
   >
     <app-content-repeater [items]="contents"></app-content-repeater>

--- a/src/app/page/component/content-card/content-card.component.spec.ts
+++ b/src/app/page/component/content-card/content-card.component.spec.ts
@@ -28,14 +28,12 @@ describe('ContentCardComponent', () => {
 
     expect(component.contents).toEqual(card.content);
     expect(component.background).toEqual(card.backgroundColor);
-    expect(component.url).toEqual(card.url);
-    expect(component.events).toEqual(card.events);
     expect(component.ready).toBeTrue();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
 
-    component.eventClick();
+    component.onClick();
 
     expect(pageService.formAction).not.toHaveBeenCalled();
   });
@@ -49,7 +47,23 @@ describe('ContentCardComponent', () => {
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
 
-    component.eventClick();
+    component.onClick();
     expect(pageService.formAction).toHaveBeenCalled();
+  });
+
+  it('fires events and opens url when both are configured', () => {
+    component.item = cardClickable;
+    component.ngOnChanges({
+      item: new SimpleChange(null, cardClickable, true)
+    });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith('URL', '_blank');
   });
 });

--- a/src/app/page/component/content-card/content-card.component.spec.ts
+++ b/src/app/page/component/content-card/content-card.component.spec.ts
@@ -1,4 +1,4 @@
-import { SimpleChange } from '@angular/core';
+import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { mockCard } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
@@ -8,13 +8,15 @@ describe('ContentCardComponent', () => {
   let component: ContentCardComponent;
   let fixture: ComponentFixture<ContentCardComponent>;
   const card = mockCard(false, false);
-  const clickableUrl = mockCard(true, true);
-  const eventClickable = mockCard(true, false);
+  const cardWithUrl = mockCard(false, true);
+  const cardWithEvents = mockCard(true, false);
+  const cardWithUrlAndEvents = mockCard(true, true);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ContentCardComponent],
-      providers: [PageService]
+      providers: [PageService],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     }).compileComponents();
     fixture = TestBed.createComponent(ContentCardComponent);
     component = fixture.componentInstance;
@@ -40,32 +42,58 @@ describe('ContentCardComponent', () => {
   });
 
   it('fires events only when clicked on with events', async () => {
-    component.item = eventClickable;
+    component.item = cardWithEvents;
     component.ngOnChanges({
-      item: new SimpleChange(null, eventClickable, true)
+      item: new SimpleChange(null, cardWithEvents, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
 
     component.onClick();
     expect(pageService.formAction).toHaveBeenCalled();
-    expect(window.open).not.toHaveBeenCalled();
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBeNull();
   });
 
   it('opens urls only when clicked on with url', async () => {
-    component.item = clickableUrl;
+    component.item = cardWithUrl;
     component.ngOnChanges({
-      item: new SimpleChange(null, clickableUrl, true)
+      item: new SimpleChange(null, cardWithUrl, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(cardWithUrl.url);
+    expect(anchor.getAttribute('target')).toBe('_blank');
 
     component.onClick();
     expect(pageService.formAction).not.toHaveBeenCalled();
-    expect(window.open).toHaveBeenCalledWith('URL', '_blank');
+  });
+
+  it('fires events and opens url when both are present', () => {
+    component.item = cardWithUrlAndEvents;
+    component.ngOnChanges({
+      item: new SimpleChange(null, cardWithUrlAndEvents, true)
+    });
+    fixture.detectChanges();
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(cardWithUrlAndEvents.url);
+    expect(anchor.getAttribute('target')).toBe('_blank');
+
+    component.onClick();
+    expect(pageService.formAction).toHaveBeenCalled();
   });
 });

--- a/src/app/page/component/content-card/content-card.component.spec.ts
+++ b/src/app/page/component/content-card/content-card.component.spec.ts
@@ -7,8 +7,9 @@ import { ContentCardComponent } from './content-card.component';
 describe('ContentCardComponent', () => {
   let component: ContentCardComponent;
   let fixture: ComponentFixture<ContentCardComponent>;
-  const card = mockCard(false);
-  const cardClickable = mockCard(true);
+  const card = mockCard(false, false);
+  const clickableUrl = mockCard(true, true);
+  const eventClickable = mockCard(true, false);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -38,23 +39,10 @@ describe('ContentCardComponent', () => {
     expect(pageService.formAction).not.toHaveBeenCalled();
   });
 
-  it('should run pageService formAction if clicked on with events', async () => {
-    component.item = cardClickable;
+  it('fires events only when clicked on with events', async () => {
+    component.item = eventClickable;
     component.ngOnChanges({
-      item: new SimpleChange(null, cardClickable, true)
-    });
-
-    const pageService = TestBed.get(PageService);
-    spyOn(pageService, 'formAction');
-
-    component.onClick();
-    expect(pageService.formAction).toHaveBeenCalled();
-  });
-
-  it('fires events and opens url when both are configured', () => {
-    component.item = cardClickable;
-    component.ngOnChanges({
-      item: new SimpleChange(null, cardClickable, true)
+      item: new SimpleChange(null, eventClickable, true)
     });
 
     const pageService = TestBed.get(PageService);
@@ -62,8 +50,22 @@ describe('ContentCardComponent', () => {
     spyOn(window, 'open');
 
     component.onClick();
-
     expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('opens urls only when clicked on with url', async () => {
+    component.item = clickableUrl;
+    component.ngOnChanges({
+      item: new SimpleChange(null, clickableUrl, true)
+    });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
+
+    component.onClick();
+    expect(pageService.formAction).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalledWith('URL', '_blank');
   });
 });

--- a/src/app/page/component/content-card/content-card.component.ts
+++ b/src/app/page/component/content-card/content-card.component.ts
@@ -4,7 +4,6 @@ import {
   Content,
   EventId
 } from 'src/app/services/xml-parser-service/xml-parser.service';
-import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
@@ -45,10 +44,8 @@ export class ContentCardComponent implements OnChanges {
     }
   }
 
-  async eventClick(): Promise<void> {
-    if (this.events.length)
-      await this.pageService.formAction(formatEvents(this.events));
-    if (this.url) window.open(this.url, '_blank');
+  eventClick(): void {
+    this.pageService.handleClickable(this.events, this.url);
   }
 
   private init(): void {

--- a/src/app/page/component/content-card/content-card.component.ts
+++ b/src/app/page/component/content-card/content-card.component.ts
@@ -42,7 +42,7 @@ export class ContentCardComponent implements OnChanges {
   }
 
   onClick(): void {
-    this.pageService.handleClickable(this.card.events, this.card.url);
+    this.pageService.handleClickable(this.card.events);
   }
 
   private init(): void {

--- a/src/app/page/component/content-card/content-card.component.ts
+++ b/src/app/page/component/content-card/content-card.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import {
   Card,
-  Content,
-  EventId
+  Content
 } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { PageService } from '../../service/page-service.service';
 
@@ -16,8 +15,6 @@ export class ContentCardComponent implements OnChanges {
   card: Card;
   contents: Content[];
   background: string;
-  url: string;
-  events: EventId[];
   ready: boolean;
   state: any;
 
@@ -44,14 +41,12 @@ export class ContentCardComponent implements OnChanges {
     }
   }
 
-  eventClick(): void {
-    this.pageService.handleClickable(this.events, this.url);
+  onClick(): void {
+    this.pageService.handleClickable(this.card.events, this.card.url);
   }
 
   private init(): void {
     this.background = this.card.backgroundColor;
-    this.events = this.card.events;
-    this.url = this.card.url;
     const contents: Content[] = [];
     this.card.content.forEach((content) =>
       content ? contents.push(content) : null

--- a/src/app/page/component/content-image/content-image.component.css
+++ b/src/app/page/component/content-image/content-image.component.css
@@ -1,12 +1,19 @@
 :host {
-    width: 100%;
-    display: block;    
+  width: 100%;
+  display: block;
 }
 
 .imageContent {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 :host:not(:first-child) .imageContent {
-    margin-top: 24px;
+  margin-top: 24px;
+}
+
+button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
 }

--- a/src/app/page/component/content-image/content-image.component.html
+++ b/src/app/page/component/content-image/content-image.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="ready">
-  <a *ngIf="isEventType" (click)="formAction()" href="javascript:void(0)">
+  <a *ngIf="isClickable" (click)="formAction()" href="javascript:void(0)">
     <img
       class="imageContent ng-binding"
       [ngClass]="{ firstImage: isFirstPage$ | async }"
@@ -9,7 +9,7 @@
     />
   </a>
   <img
-    *ngIf="!isEventType"
+    *ngIf="!isClickable"
     class="imageContent ng-binding"
     [ngClass]="{ firstImage: isFirstPage$ | async }"
     [src]="imgResource"

--- a/src/app/page/component/content-image/content-image.component.html
+++ b/src/app/page/component/content-image/content-image.component.html
@@ -1,6 +1,14 @@
 <ng-container *ngIf="ready">
+  <img
+    *ngIf="!isClickable"
+    class="imageContent ng-binding"
+    [ngClass]="{ firstImage: isFirstPage$ | async }"
+    [src]="imgResource"
+    [ngStyle]="{ width: width }"
+    alt=""
+  />
   <a
-    *ngIf="image.url; else nonUrlImage"
+    *ngIf="isClickable && image.url; else nonUrlImage"
     [href]="image.url"
     target="_blank"
     rel="noopener noreferrer"
@@ -15,11 +23,7 @@
     />
   </a>
   <ng-template #nonUrlImage>
-    <button
-      *ngIf="isClickable; else nonClickableImage"
-      type="button"
-      (click)="onClick()"
-    >
+    <button type="button" (click)="onClick()">
       <img
         class="imageContent ng-binding"
         [ngClass]="{ firstImage: isFirstPage$ | async }"
@@ -28,14 +32,5 @@
         alt=""
       />
     </button>
-    <ng-template #nonClickableImage>
-      <img
-        class="imageContent ng-binding"
-        [ngClass]="{ firstImage: isFirstPage$ | async }"
-        [src]="imgResource"
-        [ngStyle]="{ width: width }"
-        alt=""
-      />
-    </ng-template>
   </ng-template>
 </ng-container>

--- a/src/app/page/component/content-image/content-image.component.html
+++ b/src/app/page/component/content-image/content-image.component.html
@@ -1,5 +1,11 @@
 <ng-container *ngIf="ready">
-  <a *ngIf="isClickable" (click)="onClick()" href="javascript:void(0)">
+  <a
+    *ngIf="image.url; else nonUrlImage"
+    [href]="image.url"
+    target="_blank"
+    rel="noopener noreferrer"
+    (click)="onClick()"
+  >
     <img
       class="imageContent ng-binding"
       [ngClass]="{ firstImage: isFirstPage$ | async }"
@@ -8,12 +14,28 @@
       alt=""
     />
   </a>
-  <img
-    *ngIf="!isClickable"
-    class="imageContent ng-binding"
-    [ngClass]="{ firstImage: isFirstPage$ | async }"
-    [src]="imgResource"
-    [ngStyle]="{ width: width }"
-    alt=""
-  />
+  <ng-template #nonUrlImage>
+    <button
+      *ngIf="isClickable; else nonClickableImage"
+      type="button"
+      (click)="onClick()"
+    >
+      <img
+        class="imageContent ng-binding"
+        [ngClass]="{ firstImage: isFirstPage$ | async }"
+        [src]="imgResource"
+        [ngStyle]="{ width: width }"
+        alt=""
+      />
+    </button>
+    <ng-template #nonClickableImage>
+      <img
+        class="imageContent ng-binding"
+        [ngClass]="{ firstImage: isFirstPage$ | async }"
+        [src]="imgResource"
+        [ngStyle]="{ width: width }"
+        alt=""
+      />
+    </ng-template>
+  </ng-template>
 </ng-container>

--- a/src/app/page/component/content-image/content-image.component.html
+++ b/src/app/page/component/content-image/content-image.component.html
@@ -23,7 +23,7 @@
     />
   </a>
   <ng-template #nonUrlImage>
-    <button type="button" (click)="onClick()">
+    <button *ngIf="isClickable" type="button" (click)="onClick()">
       <img
         class="imageContent ng-binding"
         [ngClass]="{ firstImage: isFirstPage$ | async }"

--- a/src/app/page/component/content-image/content-image.component.html
+++ b/src/app/page/component/content-image/content-image.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="ready">
-  <a *ngIf="isClickable" (click)="formAction()" href="javascript:void(0)">
+  <a *ngIf="isClickable" (click)="onClick()" href="javascript:void(0)">
     <img
       class="imageContent ng-binding"
       [ngClass]="{ firstImage: isFirstPage$ | async }"

--- a/src/app/page/component/content-image/content-image.component.spec.ts
+++ b/src/app/page/component/content-image/content-image.component.spec.ts
@@ -1,5 +1,6 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { Image } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { mockImage } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
 import { ContentImageComponent } from './content-image.component';
@@ -10,8 +11,15 @@ describe('ContentImageComponent', () => {
   const fileName = 'name-of-file.png';
   const filePath = `/some-folder/${fileName}`;
   const imageEvent = 'page3';
+  const url = 'https://example.com';
   const image = mockImage(fileName, filePath, imageEvent);
-  const imageWithoutEvents = mockImage(fileName, filePath);
+  const imageOnlyEvents = { ...image, url: null } as Image;
+  const imageOnlyUrl = { ...mockImage(fileName, filePath), url } as Image;
+  const imageWithEventsAndUrl = { ...image, url } as Image;
+  const imageNotClickable = {
+    ...mockImage(fileName, filePath),
+    url: null
+  } as Image;
   const fileNameNotAdded = 'name-of-file-not-added.png';
   const filePathNotAdded = `/some-folder/${fileName}`;
   const imageNoNameNotAdded = mockImage(fileNameNotAdded, filePathNotAdded);
@@ -53,7 +61,7 @@ describe('ContentImageComponent', () => {
       item: new SimpleChange(null, image, true)
     });
 
-    expect(component.isEventType).toBeTrue();
+    expect(component.isClickable).toBeTrue();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
@@ -63,14 +71,41 @@ describe('ContentImageComponent', () => {
     expect(pageService.formAction).toHaveBeenCalledWith(imageEvent);
   });
 
-  describe('isEventType', () => {
-    it('should be false when no events are provided', () => {
-      component.item = imageWithoutEvents;
+  describe('isClickable', () => {
+    it('should be true when only events are provided', () => {
+      component.item = imageOnlyEvents;
       component.ngOnChanges({
-        item: new SimpleChange(null, imageWithoutEvents, true)
+        item: new SimpleChange(null, imageOnlyEvents, true)
       });
 
-      expect(component.isEventType).toBeFalse();
+      expect(component.isClickable).toBeTrue();
+    });
+
+    it('should be true when only url is provided', () => {
+      component.item = imageOnlyUrl;
+      component.ngOnChanges({
+        item: new SimpleChange(null, imageOnlyUrl, true)
+      });
+
+      expect(component.isClickable).toBeTrue();
+    });
+
+    it('should be true when both events and url are provided', () => {
+      component.item = imageWithEventsAndUrl;
+      component.ngOnChanges({
+        item: new SimpleChange(null, imageWithEventsAndUrl, true)
+      });
+
+      expect(component.isClickable).toBeTrue();
+    });
+
+    it('should be false when no events or urls are provided', () => {
+      component.item = imageNotClickable;
+      component.ngOnChanges({
+        item: new SimpleChange(null, imageNotClickable, true)
+      });
+
+      expect(component.isClickable).toBeFalse();
     });
   });
 });

--- a/src/app/page/component/content-image/content-image.component.spec.ts
+++ b/src/app/page/component/content-image/content-image.component.spec.ts
@@ -49,13 +49,12 @@ describe('ContentImageComponent', () => {
     expect(pageService.findAttachment).toHaveBeenCalledWith(fileNameNotAdded);
   });
 
-  it('correctly calls events', () => {
-    component.item = imageWithEventsAndUrl;
+  it('fires events only when clicked on with events', () => {
+    component.item = imageOnlyEvents;
     component.ngOnChanges({
-      item: new SimpleChange(null, imageWithEventsAndUrl, true)
+      item: new SimpleChange(null, imageOnlyEvents, true)
     });
-
-    expect(component.isClickable).toBeTrue();
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
@@ -63,22 +62,8 @@ describe('ContentImageComponent', () => {
     component.onClick();
 
     expect(pageService.formAction).toHaveBeenCalledWith(imageEvent);
-  });
-
-  it('fires events only when clicked on with events', () => {
-    component.item = imageOnlyEvents;
-    component.ngOnChanges({
-      item: new SimpleChange(null, imageOnlyEvents, true)
-    });
-
-    const pageService = TestBed.get(PageService);
-    spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
-
-    component.onClick();
-
-    expect(pageService.formAction).toHaveBeenCalled();
-    expect(window.open).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.querySelector('a')).toBeNull();
+    expect(fixture.nativeElement.querySelector('button')).toBeTruthy();
   });
 
   it('opens urls only when clicked on with url', () => {
@@ -86,15 +71,38 @@ describe('ContentImageComponent', () => {
     component.ngOnChanges({
       item: new SimpleChange(null, imageOnlyUrl, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
-    spyOn(window, 'open');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(filePath);
+    expect(anchor.getAttribute('target')).toBe('_blank');
 
     component.onClick();
-
     expect(pageService.formAction).not.toHaveBeenCalled();
-    expect(window.open).toHaveBeenCalledWith(filePath, '_blank');
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+
+  it('fires events and opens url when both are present', () => {
+    component.item = imageWithEventsAndUrl;
+    component.ngOnChanges({
+      item: new SimpleChange(null, imageWithEventsAndUrl, true)
+    });
+    fixture.detectChanges();
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(filePath);
+    expect(anchor.getAttribute('target')).toBe('_blank');
+
+    component.onClick();
+    expect(pageService.formAction).toHaveBeenCalledWith(imageEvent);
   });
 
   describe('isClickable', () => {

--- a/src/app/page/component/content-image/content-image.component.spec.ts
+++ b/src/app/page/component/content-image/content-image.component.spec.ts
@@ -60,9 +60,25 @@ describe('ContentImageComponent', () => {
     const pageService = TestBed.get(PageService);
     spyOn(pageService, 'formAction');
 
-    component.formAction();
+    component.onClick();
 
     expect(pageService.formAction).toHaveBeenCalledWith(imageEvent);
+  });
+
+  it('fires events and opens url when both are configured', () => {
+    component.item = imageWithEventsAndUrl;
+    component.ngOnChanges({
+      item: new SimpleChange(null, imageWithEventsAndUrl, true)
+    });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(filePath, '_blank');
   });
 
   describe('isClickable', () => {

--- a/src/app/page/component/content-image/content-image.component.spec.ts
+++ b/src/app/page/component/content-image/content-image.component.spec.ts
@@ -65,10 +65,10 @@ describe('ContentImageComponent', () => {
     expect(pageService.formAction).toHaveBeenCalledWith(imageEvent);
   });
 
-  it('fires events and opens url when both are configured', () => {
-    component.item = imageWithEventsAndUrl;
+  it('fires events only when clicked on with events', () => {
+    component.item = imageOnlyEvents;
     component.ngOnChanges({
-      item: new SimpleChange(null, imageWithEventsAndUrl, true)
+      item: new SimpleChange(null, imageOnlyEvents, true)
     });
 
     const pageService = TestBed.get(PageService);
@@ -78,6 +78,22 @@ describe('ContentImageComponent', () => {
     component.onClick();
 
     expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('opens urls only when clicked on with url', () => {
+    component.item = imageOnlyUrl;
+    component.ngOnChanges({
+      item: new SimpleChange(null, imageOnlyUrl, true)
+    });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(pageService, 'formAction');
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalledWith(filePath, '_blank');
   });
 

--- a/src/app/page/component/content-image/content-image.component.spec.ts
+++ b/src/app/page/component/content-image/content-image.component.spec.ts
@@ -1,6 +1,5 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { Image } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { mockImage } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
 import { ContentImageComponent } from './content-image.component';
@@ -11,15 +10,10 @@ describe('ContentImageComponent', () => {
   const fileName = 'name-of-file.png';
   const filePath = `/some-folder/${fileName}`;
   const imageEvent = 'page3';
-  const url = 'https://example.com';
-  const image = mockImage(fileName, filePath, imageEvent);
-  const imageOnlyEvents = { ...image, url: null } as Image;
-  const imageOnlyUrl = { ...mockImage(fileName, filePath), url } as Image;
-  const imageWithEventsAndUrl = { ...image, url } as Image;
-  const imageNotClickable = {
-    ...mockImage(fileName, filePath),
-    url: null
-  } as Image;
+  const imageOnlyEvents = mockImage(fileName, null, imageEvent);
+  const imageOnlyUrl = mockImage(fileName, filePath, null);
+  const imageWithEventsAndUrl = mockImage(fileName, filePath, imageEvent);
+  const imageNotClickable = mockImage(fileName, null, null);
   const fileNameNotAdded = 'name-of-file-not-added.png';
   const filePathNotAdded = `/some-folder/${fileName}`;
   const imageNoNameNotAdded = mockImage(fileNameNotAdded, filePathNotAdded);
@@ -39,9 +33,9 @@ describe('ContentImageComponent', () => {
   }));
 
   it('Fetch image from pageService', async () => {
-    component.item = image;
+    component.item = imageWithEventsAndUrl;
     component.ngOnChanges({
-      item: new SimpleChange(null, image, true)
+      item: new SimpleChange(null, imageWithEventsAndUrl, true)
     });
     expect(pageService.findAttachment).not.toHaveBeenCalledWith(fileName);
     expect(component.imgResource).toBe(filePath);
@@ -56,9 +50,9 @@ describe('ContentImageComponent', () => {
   });
 
   it('correctly calls events', () => {
-    component.item = image;
+    component.item = imageWithEventsAndUrl;
     component.ngOnChanges({
-      item: new SimpleChange(null, image, true)
+      item: new SimpleChange(null, imageWithEventsAndUrl, true)
     });
 
     expect(component.isClickable).toBeTrue();

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -68,7 +68,7 @@ export class ContentImageComponent implements OnChanges {
       ? dimensions.value + dimensions.symbol
       : null;
     this.events = this.image.events;
-    this.isClickable = !!this.events?.length || !!this.image.url;
+    this.isClickable = this.image.isClickable;
     this.ready = true;
   }
 }

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
   DimensionParser,
-  EventId,
   Image
 } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { PageService } from '../../service/page-service.service';
@@ -20,7 +19,6 @@ export class ContentImageComponent implements OnChanges {
   imgResource: string;
   isFirstPage$: Observable<boolean>;
   width: string;
-  events: EventId[];
   isClickable: boolean;
 
   constructor(private pageService: PageService) {
@@ -47,8 +45,8 @@ export class ContentImageComponent implements OnChanges {
     }
   }
 
-  formAction(): void {
-    this.pageService.handleClickable(this.events, this.image.url);
+  onClick(): void {
+    this.pageService.handleClickable(this.image.events, this.image.url);
   }
 
   private init(): void {
@@ -67,7 +65,6 @@ export class ContentImageComponent implements OnChanges {
     this.width = dimensions?.value
       ? dimensions.value + dimensions.symbol
       : null;
-    this.events = this.image.events;
     this.isClickable = this.image.isClickable;
     this.ready = true;
   }

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -5,7 +5,6 @@ import {
   EventId,
   Image
 } from 'src/app/services/xml-parser-service/xml-parser.service';
-import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
@@ -22,7 +21,7 @@ export class ContentImageComponent implements OnChanges {
   isFirstPage$: Observable<boolean>;
   width: string;
   events: EventId[];
-  isEventType: boolean;
+  isClickable: boolean;
 
   constructor(private pageService: PageService) {
     this.isFirstPage$ = this.pageService.isFirstPage$;
@@ -49,9 +48,7 @@ export class ContentImageComponent implements OnChanges {
   }
 
   formAction(): void {
-    if (this.events && this.isEventType) {
-      this.pageService.formAction(formatEvents(this.events));
-    }
+    this.pageService.handleClickable(this.events, this.image.url);
   }
 
   private init(): void {
@@ -71,7 +68,7 @@ export class ContentImageComponent implements OnChanges {
       ? dimensions.value + dimensions.symbol
       : null;
     this.events = this.image.events;
-    this.isEventType = !!this.events?.length;
+    this.isClickable = !!this.events?.length || !!this.image.url;
     this.ready = true;
   }
 }

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -46,7 +46,7 @@ export class ContentImageComponent implements OnChanges {
   }
 
   onClick(): void {
-    this.pageService.handleClickable(this.image.events, this.image.url);
+    this.pageService.handleClickable(this.image.events);
   }
 
   private init(): void {

--- a/src/app/page/component/content-link/content-link.component.css
+++ b/src/app/page/component/content-link/content-link.component.css
@@ -1,4 +1,13 @@
 :host {
     width: 100%;
-    display: block;    
+    display: block;
+}
+
+button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
 }

--- a/src/app/page/component/content-link/content-link.component.html
+++ b/src/app/page/component/content-link/content-link.component.html
@@ -1,5 +1,15 @@
 <ng-container *ngIf="ready">
   <div class="linkContent indent">
-    <a (click)="onClick()" href="javascript:void(0)">{{ linkText }}</a>
+    <a
+      *ngIf="link.url; else linkTemplate"
+      [href]="link.url"
+      target="_blank"
+      rel="noopener noreferrer"
+      (click)="onClick()"
+      >{{ linkText }}</a
+    >
+    <ng-template #linkTemplate>
+      <button type="button" (click)="onClick()">{{ linkText }}</button>
+    </ng-template>
   </div>
 </ng-container>

--- a/src/app/page/component/content-link/content-link.component.html
+++ b/src/app/page/component/content-link/content-link.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="ready">
   <div class="linkContent indent">
-    <a (click)="formAction(events)" href="javascript:void(0)">{{ linkText }}</a>
+    <a (click)="onClick()" href="javascript:void(0)">{{ linkText }}</a>
   </div>
 </ng-container>

--- a/src/app/page/component/content-link/content-link.component.spec.ts
+++ b/src/app/page/component/content-link/content-link.component.spec.ts
@@ -8,7 +8,8 @@ describe('ContentLinkComponent', () => {
   let component: ContentLinkComponent;
   let fixture: ComponentFixture<ContentLinkComponent>;
   let pageService: PageService;
-  const link = mockLink('https://cru.org', 'link text');
+  const linkWithUrl = mockLink('https://cru.org', 'link text');
+  const linkWithEvents = mockLink(null, 'link text');
 
   beforeEach(waitForAsync(() => {
     pageService = new PageService();
@@ -23,37 +24,44 @@ describe('ContentLinkComponent', () => {
   }));
 
   it('Values are assigned correctly', async () => {
-    component.item = link;
+    component.item = linkWithUrl;
     component.ngOnChanges({
-      item: new SimpleChange(null, link, true)
+      item: new SimpleChange(null, linkWithUrl, true)
     });
 
-    expect(component.text).toEqual(link.text);
+    expect(component.text).toEqual(linkWithUrl.text);
     expect(component.linkText).toBe('link text');
   });
 
-  it('Form Action function sends the correct info to pageService', async () => {
-    component.item = link;
+  it('fires events only when clicked on with events', () => {
+    component.item = linkWithEvents;
     component.ngOnChanges({
-      item: new SimpleChange(null, link, true)
+      item: new SimpleChange(null, linkWithEvents, true)
     });
-
-    component.onClick();
-    expect(pageService.formAction).toHaveBeenCalledWith(
-      'followup-testing-event followup:send'
-    );
-  });
-
-  it('fires events and opens url when both are configured', () => {
-    component.item = link;
-    component.ngOnChanges({ item: new SimpleChange(null, link, true) });
 
     const pageService = TestBed.get(PageService);
     spyOn(window, 'open');
 
     component.onClick();
 
-    expect(pageService.formAction).toHaveBeenCalled();
+    expect(pageService.formAction).toHaveBeenCalledWith(
+      'followup-testing-event followup:send'
+    );
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('opens urls only when clicked on with url', () => {
+    component.item = linkWithUrl;
+    component.ngOnChanges({
+      item: new SimpleChange(null, linkWithUrl, true)
+    });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalledWith('https://cru.org', '_blank');
   });
 });

--- a/src/app/page/component/content-link/content-link.component.spec.ts
+++ b/src/app/page/component/content-link/content-link.component.spec.ts
@@ -9,7 +9,8 @@ describe('ContentLinkComponent', () => {
   let fixture: ComponentFixture<ContentLinkComponent>;
   let pageService: PageService;
   const linkWithUrl = mockLink('https://cru.org', 'link text');
-  const linkWithEvents = mockLink(null, 'link text');
+  const linkWithEvents = mockLink(null, 'link text', true);
+  const linkWithUrlAndEvents = mockLink('https://cru.org', 'link text', true);
 
   beforeEach(waitForAsync(() => {
     pageService = new PageService();
@@ -38,16 +39,16 @@ describe('ContentLinkComponent', () => {
     component.ngOnChanges({
       item: new SimpleChange(null, linkWithEvents, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
-    spyOn(window, 'open');
-
     component.onClick();
 
     expect(pageService.formAction).toHaveBeenCalledWith(
       'followup-testing-event followup:send'
     );
-    expect(window.open).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.querySelector('a')).toBeNull();
+    expect(fixture.nativeElement.querySelector('button')).toBeTruthy();
   });
 
   it('opens urls only when clicked on with url', () => {
@@ -55,13 +56,37 @@ describe('ContentLinkComponent', () => {
     component.ngOnChanges({
       item: new SimpleChange(null, linkWithUrl, true)
     });
+    fixture.detectChanges();
 
     const pageService = TestBed.get(PageService);
-    spyOn(window, 'open');
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(linkWithUrl.url);
+    expect(anchor.getAttribute('target')).toBe('_blank');
 
     component.onClick();
-
     expect(pageService.formAction).not.toHaveBeenCalled();
-    expect(window.open).toHaveBeenCalledWith('https://cru.org', '_blank');
+    expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+
+  it('fires events and opens url when both are present', () => {
+    component.item = linkWithUrlAndEvents;
+    component.ngOnChanges({
+      item: new SimpleChange(null, linkWithUrlAndEvents, true)
+    });
+    fixture.detectChanges();
+
+    const pageService = TestBed.get(PageService);
+
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor.getAttribute('href')).toBe(linkWithUrlAndEvents.url);
+    expect(anchor.getAttribute('target')).toBe('_blank');
+
+    component.onClick();
+    expect(pageService.formAction).toHaveBeenCalledWith(
+      'followup-testing-event followup:send'
+    );
   });
 });

--- a/src/app/page/component/content-link/content-link.component.spec.ts
+++ b/src/app/page/component/content-link/content-link.component.spec.ts
@@ -4,11 +4,11 @@ import { mockLink } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
 import { ContentLinkComponent } from './content-link.component';
 
-describe('ContentInputComponent', () => {
+describe('ContentLinkComponent', () => {
   let component: ContentLinkComponent;
   let fixture: ComponentFixture<ContentLinkComponent>;
   let pageService: PageService;
-  const link = mockLink('https://cru.org', 'link text', true);
+  const link = mockLink('https://cru.org', 'link text');
 
   beforeEach(waitForAsync(() => {
     pageService = new PageService();
@@ -30,7 +30,6 @@ describe('ContentInputComponent', () => {
 
     expect(component.text).toEqual(link.text);
     expect(component.linkText).toBe('link text');
-    expect(component.events).toEqual(link.events);
   });
 
   it('Form Action function sends the correct info to pageService', async () => {
@@ -39,9 +38,22 @@ describe('ContentInputComponent', () => {
       item: new SimpleChange(null, link, true)
     });
 
-    component.formAction();
+    component.onClick();
     expect(pageService.formAction).toHaveBeenCalledWith(
       'followup-testing-event followup:send'
     );
+  });
+
+  it('fires events and opens url when both are configured', () => {
+    component.item = link;
+    component.ngOnChanges({ item: new SimpleChange(null, link, true) });
+
+    const pageService = TestBed.get(PageService);
+    spyOn(window, 'open');
+
+    component.onClick();
+
+    expect(pageService.formAction).toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith('https://cru.org', '_blank');
   });
 });

--- a/src/app/page/component/content-link/content-link.component.ts
+++ b/src/app/page/component/content-link/content-link.component.ts
@@ -5,7 +5,6 @@ import {
   Link,
   Text
 } from 'src/app/services/xml-parser-service/xml-parser.service';
-import { formatEvents } from 'src/app/shared/formatEvents';
 import { PageService } from '../../service/page-service.service';
 
 @Component({
@@ -50,9 +49,7 @@ export class ContentLinkComponent implements OnChanges {
   }
 
   formAction(): void {
-    if (this.events) {
-      this.pageService.formAction(formatEvents(this.events));
-    }
+    this.pageService.handleClickable(this.events, this.link.url);
   }
 
   private init(): void {

--- a/src/app/page/component/content-link/content-link.component.ts
+++ b/src/app/page/component/content-link/content-link.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
-  EventId,
   Link,
   Text
 } from 'src/app/services/xml-parser-service/xml-parser.service';
@@ -19,7 +18,6 @@ export class ContentLinkComponent implements OnChanges {
   text: Text;
   ready: boolean;
   linkText: string;
-  events: EventId[];
   dir$: Observable<string>;
 
   constructor(private pageService: PageService) {
@@ -37,7 +35,6 @@ export class ContentLinkComponent implements OnChanges {
             ) {
               this.ready = false;
               this.linkText = '';
-              this.events = null;
               this.text = null;
               this.link = this.item;
               this.init();
@@ -48,14 +45,13 @@ export class ContentLinkComponent implements OnChanges {
     }
   }
 
-  formAction(): void {
-    this.pageService.handleClickable(this.events, this.link.url);
+  onClick(): void {
+    this.pageService.handleClickable(this.link.events, this.link.url);
   }
 
   private init(): void {
     this.text = this.link.text || null;
     this.linkText = this.link.text?.text || '';
-    this.events = this.link.events;
     this.ready = true;
   }
 }

--- a/src/app/page/component/content-link/content-link.component.ts
+++ b/src/app/page/component/content-link/content-link.component.ts
@@ -46,7 +46,7 @@ export class ContentLinkComponent implements OnChanges {
   }
 
   onClick(): void {
-    this.pageService.handleClickable(this.link.events, this.link.url);
+    this.pageService.handleClickable(this.link.events);
   }
 
   private init(): void {

--- a/src/app/page/service/page-service.service.spec.ts
+++ b/src/app/page/service/page-service.service.spec.ts
@@ -25,26 +25,14 @@ describe('PageService', () => {
       spyOn(window, 'open');
     });
 
-    it('fires events and opens url when both are present', () => {
-      service.handleClickable([createEventId('foo')], 'https://example.com');
-      expect(service.formAction).toHaveBeenCalledWith('foo');
-      expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank');
-    });
-
-    it('fires events when url not present', () => {
-      service.handleClickable([createEventId('foo')], null);
+    it('fires events when events are present', () => {
+      service.handleClickable([createEventId('foo')]);
       expect(service.formAction).toHaveBeenCalledWith('foo');
       expect(window.open).not.toHaveBeenCalled();
     });
 
-    it('opens url only when events not present', () => {
-      service.handleClickable([], 'https://example.com');
-      expect(service.formAction).not.toHaveBeenCalled();
-      expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank');
-    });
-
-    it('does nothing when neither events nor url are provided', () => {
-      service.handleClickable([], null);
+    it('does nothing when events are not provided', () => {
+      service.handleClickable([]);
       expect(service.formAction).not.toHaveBeenCalled();
       expect(window.open).not.toHaveBeenCalled();
     });

--- a/src/app/page/service/page-service.service.spec.ts
+++ b/src/app/page/service/page-service.service.spec.ts
@@ -25,11 +25,8 @@ describe('PageService', () => {
       spyOn(window, 'open');
     });
 
-    it('fires events and opens url when both are present', async () => {
-      await service.handleClickable(
-        [createEventId('foo')],
-        'https://example.com'
-      );
+    it('fires events and opens url when both are present', () => {
+      service.handleClickable([createEventId('foo')], 'https://example.com');
       expect(service.formAction).toHaveBeenCalledWith('foo');
       expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank');
     });

--- a/src/app/page/service/page-service.service.spec.ts
+++ b/src/app/page/service/page-service.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed, inject } from '@angular/core/testing';
+import { createEventId } from 'src/app/_tests/mocks';
 import { PageService } from './page-service.service';
 
 describe('PageService', () => {
@@ -16,6 +17,40 @@ describe('PageService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('handleClickable', () => {
+    beforeEach(() => {
+      spyOn(service, 'formAction');
+      spyOn(window, 'open');
+    });
+
+    it('fires events and opens url when both are present', async () => {
+      await service.handleClickable(
+        [createEventId('foo')],
+        'https://example.com'
+      );
+      expect(service.formAction).toHaveBeenCalledWith('foo');
+      expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank');
+    });
+
+    it('fires events when url not present', () => {
+      service.handleClickable([createEventId('foo')], null);
+      expect(service.formAction).toHaveBeenCalledWith('foo');
+      expect(window.open).not.toHaveBeenCalled();
+    });
+
+    it('opens url only when events not present', () => {
+      service.handleClickable([], 'https://example.com');
+      expect(service.formAction).not.toHaveBeenCalled();
+      expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank');
+    });
+
+    it('does nothing when neither events nor url are provided', () => {
+      service.handleClickable([], null);
+      expect(service.formAction).not.toHaveBeenCalled();
+      expect(window.open).not.toHaveBeenCalled();
+    });
   });
 
   it('addToNavigationStack() should add a page to the stack', (done) => {

--- a/src/app/page/service/page-service.service.ts
+++ b/src/app/page/service/page-service.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { State } from '../../services/xml-parser-service/xml-parser.service';
+import { formatEvents } from 'src/app/shared/formatEvents';
+import {
+  EventId,
+  State
+} from '../../services/xml-parser-service/xml-parser.service';
 
 @Injectable({
   providedIn: 'root'
@@ -183,6 +187,15 @@ export class PageService {
 
   parserState(): any {
     return this.XmlParserState;
+  }
+
+  async handleClickable(events: EventId[], url: string): Promise<void> {
+    if (events && events.length) {
+      await this.formAction(formatEvents(events));
+    }
+    if (url) {
+      window.open(url, '_blank');
+    }
   }
 
   // CYOA Navigation Stack/Array

--- a/src/app/page/service/page-service.service.ts
+++ b/src/app/page/service/page-service.service.ts
@@ -189,7 +189,7 @@ export class PageService {
     return this.XmlParserState;
   }
 
-  handleClickable(events: EventId[], url: string): void {
+  handleClickable(events: EventId[]): void {
     if (events && events.length) {
       // Each event can resolve into an array of events, so combine them into a single array.
       // This is necessary to support complex form actions with 'state' in the EventId.
@@ -201,9 +201,6 @@ export class PageService {
       );
 
       this.formAction(formatEvents(resolvedEvents));
-    }
-    if (url) {
-      window.open(url, '_blank');
     }
   }
 

--- a/src/app/page/service/page-service.service.ts
+++ b/src/app/page/service/page-service.service.ts
@@ -189,7 +189,7 @@ export class PageService {
     return this.XmlParserState;
   }
 
-  async handleClickable(events: EventId[], url: string): Promise<void> {
+  handleClickable(events: EventId[], url: string): void {
     if (events && events.length) {
       // Each event can resolve into an array of events, so combine them into a single array.
       // This is necessary to support complex form actions with 'state' in the EventId.
@@ -200,7 +200,7 @@ export class PageService {
         )
       );
 
-      await this.formAction(formatEvents(resolvedEvents));
+      this.formAction(formatEvents(resolvedEvents));
     }
     if (url) {
       window.open(url, '_blank');

--- a/src/app/page/service/page-service.service.ts
+++ b/src/app/page/service/page-service.service.ts
@@ -191,7 +191,16 @@ export class PageService {
 
   async handleClickable(events: EventId[], url: string): Promise<void> {
     if (events && events.length) {
-      await this.formAction(formatEvents(events));
+      // Each event can resolve into an array of events, so combine them into a single array.
+      // This is necessary to support complex form actions with 'state' in the EventId.
+      // (`Array.flatMap` isn't supported yet, so we use `[].concat(...arrays)`)
+      const resolvedEvents = [].concat(
+        ...events.map((event) =>
+          event.resolve(this.parserState()).asJsReadonlyArrayView()
+        )
+      );
+
+      await this.formAction(formatEvents(resolvedEvents));
     }
     if (url) {
       window.open(url, '_blank');


### PR DESCRIPTION
We want to standardize support for Clickable elements so that they support firing off content events and opening a url when an item is clicked.

Components:
- Animation ✅
- Button ✅
- Card ✅ --> `en/tool/v2/openers/1`
- Image ✅
- Link 

**Jira ticket:** [GT-2035](https://jira.cru.org/browse/GT-2035)