### PR TITLE
GT-2031 Refactor image prefetcher

### DIFF
--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -689,6 +689,36 @@ export const mockBooksData = {
   ]
 };
 
+export const mockPageBookIndexData = {
+  data: { attributes: {} },
+  included: [
+    {
+      type: 'attachment',
+      attributes: {
+        sha256: 'aaa111',
+        file: 'https://cru.org/needed-1.png',
+        'file-file-name': 'needed-1.png'
+      }
+    },
+    {
+      type: 'attachment',
+      attributes: {
+        sha256: 'bbb222',
+        file: 'https://cru.org/needed-2.png',
+        'file-file-name': 'needed-2.png'
+      }
+    },
+    {
+      type: 'attachment',
+      attributes: {
+        sha256: 'zzz999',
+        file: 'https://cru.org/skipped.png',
+        'file-file-name': 'skipped.png'
+      }
+    }
+  ]
+};
+
 export const mockSpacer = (height = 100): Spacer => {
   return {
     height,

--- a/src/app/page/page.component.spec.ts
+++ b/src/app/page/page.component.spec.ts
@@ -4,12 +4,17 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   createEventId,
+  mockPageBookIndexData,
   mockPageComponent,
   mockTractPage
 } from '../_tests/mocks';
 import { CommonService } from '../services/common.service';
 import { LoaderService } from '../services/loader-service/loader.service';
-import { godToolsParser } from '../services/xml-parser-service/xml-parser.service';
+import {
+  ManifestParser,
+  XmlParserData,
+  godToolsParser
+} from '../services/xml-parser-service/xml-parser.service';
 import { PageComponent, getResourceTypeEnum } from './page.component';
 import { PageService } from './service/page-service.service';
 
@@ -277,6 +282,49 @@ describe('PageComponent', () => {
         );
       });
     });
+  });
+
+  it('loadBookManifestXML() fetches only needed resources', async () => {
+    component._pageBookIndex = mockPageBookIndexData;
+
+    component._selectedLanguage = { id: '2222' };
+    component._pageBookTranslations = [
+      {
+        id: 'tx-1',
+        attributes: { 'manifest-name': 'foo.xml' },
+        relationships: { language: { data: { id: '2222' } } }
+      }
+    ];
+
+    const fakeManifest = {
+      relatedFiles: {
+        asJsReadonlySetView: () => new Set(['aaa111.png', 'bbb222.png'])
+      },
+      pages: []
+    };
+    spyOn(ManifestParser.prototype, 'parseManifest').and.returnValue(
+      Promise.resolve({ manifest: fakeManifest } as unknown as XmlParserData)
+    );
+
+    const addAttachmentSpy = spyOn(pageService, 'addAttachment');
+    spyOn(component, 'getResource');
+
+    component['loadBookManifestXML']();
+    await fixture.whenStable();
+
+    expect(addAttachmentSpy).toHaveBeenCalledTimes(2);
+    expect(addAttachmentSpy).toHaveBeenCalledWith(
+      'needed-1.png',
+      'https://cru.org/needed-1.png'
+    );
+    expect(addAttachmentSpy).toHaveBeenCalledWith(
+      'needed-2.png',
+      'https://cru.org/needed-2.png'
+    );
+    expect(addAttachmentSpy).not.toHaveBeenCalledWith(
+      'skipped.png',
+      'https://cru.org/skipped.png'
+    );
   });
 
   it('getAvailableLanguagesForSelectedBook() no languages downloaded', () => {

--- a/src/app/page/page.component.spec.ts
+++ b/src/app/page/page.component.spec.ts
@@ -307,23 +307,24 @@ describe('PageComponent', () => {
     );
 
     const addAttachmentSpy = spyOn(pageService, 'addAttachment');
-    spyOn(component, 'getResource');
+    const getResourceSpy = spyOn(component, 'getResource');
 
     component['loadBookManifestXML']();
     await fixture.whenStable();
 
-    expect(addAttachmentSpy).toHaveBeenCalledTimes(2);
-    expect(addAttachmentSpy).toHaveBeenCalledWith(
-      'needed-1.png',
-      'https://cru.org/needed-1.png'
+    expect(addAttachmentSpy).toHaveBeenCalledTimes(3);
+
+    expect(getResourceSpy).toHaveBeenCalledWith(
+      getResourceTypeEnum.image,
+      'needed-1.png'
     );
-    expect(addAttachmentSpy).toHaveBeenCalledWith(
-      'needed-2.png',
-      'https://cru.org/needed-2.png'
+    expect(getResourceSpy).toHaveBeenCalledWith(
+      getResourceTypeEnum.image,
+      'needed-2.png'
     );
-    expect(addAttachmentSpy).not.toHaveBeenCalledWith(
-      'skipped.png',
-      'https://cru.org/skipped.png'
+    expect(getResourceSpy).not.toHaveBeenCalledWith(
+      getResourceTypeEnum.image,
+      'skipped.png'
     );
   });
 

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -29,8 +29,6 @@ import { IPageParameters } from './model/page-parameters';
 import { PageService } from './service/page-service.service';
 
 const IMAGE_EXTENSIONS_REGEX = /\.(gif|jpe?g|tiff?|png|webp|svg|bmp)$/i;
-const SUPPORTED_EXTENSIONS_REGEX =
-  /\.(gif|jpe?g|tiff?|png|webp|svg|bmp|json)$/i;
 
 interface LiveShareSubscriptionPayload {
   data?: {
@@ -371,11 +369,11 @@ export class PageComponent implements OnInit, OnDestroy {
           const { manifest } = data as XmlParserData;
           this._pageBookManifest = manifest;
 
-          // Remove file extensions to get the SHAs
+          // Remove file extensions to get the SHAs for manifest resources
           const neededShas = new Set(
-            Array.from(manifest.relatedFiles?.asJsReadonlySetView() ?? [])
-              .filter((file) => !file.endsWith('.xml'))
-              .map((file) => file.replace(SUPPORTED_EXTENSIONS_REGEX, ''))
+            Array.from(manifest.relatedFiles?.asJsReadonlySetView() ?? []).map(
+              (file) => file.replace(/\.[^.]+$/, '')
+            )
           );
 
           // Loop through and get all needed resources.
@@ -385,14 +383,17 @@ export class PageComponent implements OnInit, OnDestroy {
             if (type !== 'attachment') {
               return;
             }
-            if (!neededShas.has(attributes.sha256)) {
-              return;
-            }
 
+            // Add all resources to the lookup table so they can be accessed by any page that needs them
             this.pageService.addAttachment(
               attributes['file-file-name'],
               attributes.file
             );
+
+            if (!neededShas.has(attributes.sha256)) {
+              return;
+            }
+
             const isImage = IMAGE_EXTENSIONS_REGEX.test(
               attributes['file-file-name']
             );

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -28,6 +28,10 @@ import {
 import { IPageParameters } from './model/page-parameters';
 import { PageService } from './service/page-service.service';
 
+const IMAGE_EXTENSIONS_REGEX = /\.(gif|jpe?g|tiff?|png|webp|svg|bmp)$/i;
+const SUPPORTED_EXTENSIONS_REGEX =
+  /\.(gif|jpe?g|tiff?|png|webp|svg|bmp|json)$/i;
+
 interface LiveShareSubscriptionPayload {
   data?: {
     type: 'navigation-event';
@@ -367,25 +371,38 @@ export class PageComponent implements OnInit, OnDestroy {
           const { manifest } = data as XmlParserData;
           this._pageBookManifest = manifest;
 
-          // Loop through and get all resources.
+          // Remove file extensions to get the SHAs
+          const neededShas = new Set(
+            Array.from(manifest.relatedFiles?.asJsReadonlySetView() ?? [])
+              .filter((file) => !file.endsWith('.xml'))
+              .map((file) => file.replace(SUPPORTED_EXTENSIONS_REGEX, ''))
+          );
+
+          // Loop through and get all needed resources.
           this._pageBookIndex.included.forEach((resource) => {
             const { attributes, type } = resource;
-            if (type === 'attachment') {
-              this.pageService.addAttachment(
-                attributes['file-file-name'],
-                attributes.file
-              );
-              const isImage = /\.(gif|jpe?g|tiff?|png|webp|svg|bmp)$/i.test(
-                attributes['file-file-name']
-              );
 
-              this.getResource(
-                isImage
-                  ? getResourceTypeEnum.image
-                  : getResourceTypeEnum.animation,
-                attributes['file-file-name']
-              );
+            if (type !== 'attachment') {
+              return;
             }
+            if (!neededShas.has(attributes.sha256)) {
+              return;
+            }
+
+            this.pageService.addAttachment(
+              attributes['file-file-name'],
+              attributes.file
+            );
+            const isImage = IMAGE_EXTENSIONS_REGEX.test(
+              attributes['file-file-name']
+            );
+
+            this.getResource(
+              isImage
+                ? getResourceTypeEnum.image
+                : getResourceTypeEnum.animation,
+              attributes['file-file-name']
+            );
           });
 
           if (manifest?.pages?.length) {


### PR DESCRIPTION
Currently, the image pre-fetcher is grabbing all resources instead of the ones that are needed. We need to refactor this function to filter out images and animations not included in the manifest.

Jira ticket: [GT-2031](https://jira.cru.org/browse/GT-2031)

**Technical Solution:**
Each manifest has a `relatedFiles` field that is an array of strings. These strings are `sha256` of resources plus a file extension, which we will use to compare to every resource:
```
"2eeb2bca42e959fe74ab23ae9f330474a323c239fa2aee6c82476daf8f3d82f4.xml"
"78c7cdab8e6cfc2782df1dd25fb447bf0f8fb4eea76aa4593a13d6c5cdab6ccf.jpg"
"85f00dabd27410cd08d23c8f6c733f80edea388af4ba875835c88ce6422253e2.png"
```

`.xml` are pages, so these won't be included; `.jpg` and `.png` are images and will be included if they are needed in the current manifest

Resource data:
```
{
    "id": "1069",
    "type": "attachment",
    "attributes": {
        "file": "https://mobile-content-api.cru.org/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NzkzLCJwdXIiOiJibG9iX2lkIn19--806555080cc5ea19387e07c8471848da0304bb65/four_En_01.jpg",
        "is-zipped": false,
        "sha256": "78c7cdab8e6cfc2782df1dd25fb447bf0f8fb4eea76aa4593a13d6c5cdab6ccf",
        "file-file-name": "four_En_01.jpg"
    },
    "relationships": {
        "resource": {
            "data": {
                "id": "6",
                "type": "resource"
            }
        }
    }
},
```

**Testing:**
You can `console.log`...
- The filenames of attachment types in `pageBookIndex` to see all possible resources
- Manifest's `relatedFiles` to see all the files the manifest uses
- The filtered resources after both checks to see the resources that are actually loaded (after line 390)
