### PR TITLE
Add contributor docs, PR template, and CruGlobal Claude Code plugins

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,21 +6,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Know God Web is an Angular 17 application that renders GodTools religious content for web and embedded (iframe) contexts. Content is fetched from Cru Global's mobile-content-api and parsed from XML manifests using `@cruglobal/godtools-shared`.
 
-**Live sites:** knowgod.com (prod/master), stage.knowgod.com (staging)
+**Live sites:** knowgod.com (prod/main), stage.knowgod.com (staging)
 
 ## Commands
 
 | Task | Command |
 |------|---------|
 | Install dependencies | `yarn install` |
-| Dev server (localhost:4200) | `npm run start:dev` |
-| Production build | `npm run build` |
-| Run all tests | `npm test` |
-| Lint (with autofix) | `npm run lint` |
-| Format check | `npm run prettier:check` |
-| Format fix | `npm run prettier:write` |
+| Dev server (localhost:4200) | `yarn start:dev` |
+| Production build | `yarn build` |
+| Run all tests | `yarn test --no-watch` |
+| Lint (with autofix) | `yarn lint` |
+| Format check | `yarn prettier:check` |
+| Format fix | `yarn prettier:write` |
 
-Tests use Karma + Jasmine with ChromeHeadless. There is no single-test runner configured; all specs run together via `ng test --watch=false`.
+Always use `yarn`, never `npm` (Yarn 4.7.0 via Corepack; see the root `CLAUDE.md`).
+
+Tests use Karma + Jasmine with ChromeHeadless. There is no single-test runner configured; all specs run together via `yarn test --no-watch`.
 
 ## Architecture
 
@@ -67,11 +69,14 @@ RxJS Subjects/BehaviorSubjects directly in services (no NgRx):
 ## Build & Deploy
 
 CI is GitHub Actions (`.github/workflows/node.js.yml`). Branches auto-deploy to AWS S3:
-- `master` -> production
+- `main` -> production
 - `staging` -> stage
 - `development` -> dev
 
-The `update-staging.yml` workflow auto-merges master -> staging -> development.
+The `update-staging.yml` workflow promotes work to lower environments via PR
+labels: `On Staging` auto-merges the branch into `staging` and `development`,
+`On Development` merges into `development` only. (Its legacy `push` trigger still
+references the old `master` branch, which no longer exists.)
 
 Build output goes to `dist/knowgod/`, plus `embed/embed.js` and `mobile/` are copied alongside.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "extraKnownMarketplaces": {
+    "cru-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "CruGlobal/claude-code-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "git@cru-plugins": true,
+    "quality@cru-plugins": true,
+    "testing@cru-plugins": true,
+    "admin@cru-plugins": true,
+    "figma@cru-plugins": true
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for know-god-web
+#
+# GitHub automatically requests a review from the owners listed here whenever a
+# pull request changes a matching path. The pattern below covers the whole repo,
+# so every PR requests a review from these people.
+#
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @kegrimes @wjames111 @dr-bizz @canac @zweatshirt

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@ Example:
 
 - [ ] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
 - [ ] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
-- [ ] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](workflows/update-staging.yml))
+- [ ] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
 - [ ] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
 - [ ] `yarn test --no-watch` passes locally
 - [ ] I have run `/agent-review` and addressed its findings before requesting a dev review

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,10 +28,11 @@ Example:
 ## Checklist:
 
 - [ ] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
-- [ ] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use a short descriptive title
+- [ ] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
 - [ ] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](workflows/update-staging.yml))
 - [ ] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
 - [ ] `yarn test --no-watch` passes locally
+- [ ] I have run `/agent-review` and addressed its findings before requesting a dev review
 - [ ] I have requested a review from another person on the project
 - [ ] I have tested my changes on staging or development
 - [ ] I have cleaned up my commit history

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Description
+
+Please explain a bullet-point summary of the changes.
+List any PRs that this PR is dependent on and any Jira tickets that this PR is related to.
+
+For UI or tool-content changes, please include before/after screenshots or a short screen recording.
+
+## Testing
+
+<!--
+Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?
+
+Tips:
+- Run the app locally with `yarn start:dev` (or check the deployed staging build once the "On Staging" label is applied).
+- If the change affects the embed, test it via `embed/example.html` and confirm the tool still loads inside the iframe.
+- Note the relevant tool/language (e.g. `data-book=kgp-us`, `data-lang=en`) the reviewer should use.
+
+Example:
+- Go to /#/en/kgp-us
+- Navigate to the next page of the tool
+- Check that the page renders correctly
+-->
+
+- Go to ...
+- Do ...
+- Check that ...
+
+## Checklist:
+
+- [ ] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
+- [ ] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use a short descriptive title
+- [ ] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](workflows/update-staging.yml))
+- [ ] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
+- [ ] `yarn test --no-watch` passes locally
+- [ ] I have requested a review from another person on the project
+- [ ] I have tested my changes on staging or development
+- [ ] I have cleaned up my commit history

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Tools are addressed by a hash route: `/#/{lang}/{book}` (e.g. `/#/en/kgp-us`).
 - **Styling:** plain CSS. Global styles in `src/styles.css`; each component has a
   co-located `*.component.css`. There is **no** Tailwind, SCSS, or CSS-modules
   setup — match the existing component-CSS pattern.
-- **Node:** pinned to 20.17.0 via `.tool-versions` (asdf). **Yarn 4.7.0** via
+- **Node:** pinned to 24.9.0 via `.tool-versions` (asdf). **Yarn 4.7.0** via
   Corepack (`.yarnrc.yml`); always use `yarn`, never `npm`.
 
 ## Directory structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+Repo-specific context for Claude Code and the CruGlobal plugins
+(`CruGlobal/claude-code-plugins`). The adaptive skills (`/quality:pr-review`,
+`/quality:code-review`, `/quality:agent-review`, `/testing:test-writer`,
+`/figma:*`) read this file to learn how this project works.
+
+## Project overview
+
+`know-god-web` (package name `knowgod`) is the **KnowGod.com embeddable web app**:
+an Angular 17 + TypeScript single-page app that renders GodTools resources (e.g.
+"Knowing God Personally", `kgp-us`). It also ships as an **embed** — third-party
+sites load a small dependency-free `embed.js` loader that runs the app inside an
+iframe and auto-resizes it via `postMessage`. See `README.md` for the full embed
+flow and `embed/example.html` for a working example.
+
+Tools are addressed by a hash route: `/#/{lang}/{book}` (e.g. `/#/en/kgp-us`).
+
+## Tech stack
+
+- **Framework:** Angular 17, TypeScript, RxJS.
+- **Shared logic:** `@cruglobal/godtools-shared` (resource/tool parsing). Prefer
+  it over re-implementing GodTools data handling.
+- **Real-time / misc:** `@rails/actioncable`, `lottie-web` / `ngx-lottie`
+  (animations), `ngx-toastr` (toasts).
+- **Styling:** plain CSS. Global styles in `src/styles.css`; each component has a
+  co-located `*.component.css`. There is **no** Tailwind, SCSS, or CSS-modules
+  setup — match the existing component-CSS pattern.
+- **Node:** pinned to 20.17.0 via `.tool-versions` (asdf). **Yarn 4.7.0** via
+  Corepack (`.yarnrc.yml`); always use `yarn`, never `npm`.
+
+## Directory structure
+
+- `src/app/page/` — the tool/page rendering engine (components for paragraphs,
+  links, tract pages, CYOA pages, etc.) under `page/component/...`.
+- `src/app/services/` — app services.
+- `src/app/shared/`, `src/app/dashboard/`, `src/app/api/` — supporting areas.
+- `src/app/_tests/` — shared test helpers and mocks (`mocks.ts`, e.g.
+  `mockLink(...)`).
+- `src/environments/` — environment configs.
+- `embed/` — the standalone `embed.js` loader and example.
+- `mobile/` — JSON assets copied into the deploy output.
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `yarn start` | Dev server, **production** config (proxies to prod backends) |
+| `yarn start:dev` | Dev server, development config (staging data) |
+| `yarn build` / `yarn build:dev` | Production / development build |
+| `yarn test --no-watch` | Run unit tests once (Karma + Jasmine) |
+| `yarn lint` | ESLint (`src/**/*.{js,ts,html}`) with `--fix` |
+| `yarn prettier:check` / `yarn prettier:write` | Check / apply formatting |
+
+Local app: <http://localhost:4200/en>.
+
+## Testing conventions
+
+- **Framework:** Karma + Jasmine. Run with `yarn test --no-watch`.
+- **File naming/placement:** specs are co-located with the component as
+  `*.component.spec.ts` (e.g. `content-link.component.spec.ts` next to
+  `content-link.component.ts`).
+- **Pattern:** use Angular's `TestBed` with `ComponentFixture`; declare the
+  component, provide services via `{ provide: X, useValue: ... }`, call
+  `fixture.detectChanges()`, and drive lifecycle hooks explicitly (e.g.
+  `ngOnChanges({ item: new SimpleChange(null, value, true) })`).
+- **Mocks:** import shared mocks/helpers from `src/app/_tests/` (e.g.
+  `mockLink`) rather than hand-rolling fixtures. Use `spyOn(service, 'method')`
+  for service interactions.
+
+## Code review heuristics
+
+- Keep components thin and presentational; put data/parsing logic in services or
+  lean on `@cruglobal/godtools-shared`.
+- Respect the **embed contract**: changes affecting layout/height must not break
+  the iframe auto-resize (`postMessage` height messaging in `src/index.html` and
+  `embed/embed.js`). The `embedded` flag (`page.component.ts`) and embedded
+  analytics tagging (`analytics.service.ts`) should keep working.
+- Don't bypass the proxy — API calls rely on `proxy.conf.json` wired through
+  `yarn start` / `yarn start:dev`.
+- New styles go in the component's co-located `.css` (or `src/styles.css` for
+  globals); don't introduce a new styling system.
+- Use `yarn`; never add `npm`/`package-lock.json` artifacts.
+
+## Figma / design-to-code
+
+- UI framework: **Angular 17** components (declared in modules; this repo is not
+  standalone-component based).
+- CSS: plain CSS, co-located per component + global `src/styles.css`. No design
+  token file exists today — emit plain CSS matching neighboring components.
+
+## Git / PR conventions
+
+- **Branch targets:** open PRs against `staging` or `main` — CI PR checks (lint,
+  prettier, test, build) only run on those branches.
+- **PR title:** `GT-(JIRA#) (summary, max 80 chars)`. `GT` = GodTools Jira
+  project; if there's no ticket, use a short descriptive title.
+- **Deploy labels:** `On Staging` auto-merges the branch into `staging` and
+  `development`; `On Development` merges into `development` only (see
+  `.github/workflows/update-staging.yml`).
+- Before opening a PR, run the four CI-mirroring checks: `yarn prettier:write`,
+  `yarn lint`, `yarn test --no-watch`, `yarn build`. A Husky pre-commit hook runs
+  `pretty-quick` on staged files.
+- See `CONTRIBUTING.md` and `README.md` for the full workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,5 +100,5 @@ Local app: <http://localhost:4200/en>.
   `.github/workflows/update-staging.yml`).
 - Before opening a PR, run the four CI-mirroring checks: `yarn prettier:write`,
   `yarn lint`, `yarn test --no-watch`, `yarn build`. A Husky pre-commit hook runs
-  `pretty-quick` on staged files.
+  `yarn lint` and `yarn prettier:check`.
 - See `CONTRIBUTING.md` and `README.md` for the full workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to know-god-web
+
+Thanks for working on the Know God web app. This guide gets a new teammate or
+contractor from zero to a merged PR. It intentionally stays short and links to
+the [README](README.md) for the deep detail.
+
+## 1. Get set up
+
+Follow the **Getting started** steps in the [README](README.md): install the
+pinned Node version with asdf (`.tool-versions` → Node 20.17.0), confirm Yarn
+4.7.0 resolves (enable Corepack if not), run `yarn` to install, then `yarn start`
+(production data) or `yarn start:dev` (staging data) and open
+<http://localhost:4200/en>.
+
+If anything misbehaves, check the README's **Troubleshooting** section first —
+the common asdf / Corepack / proxy issues are covered there.
+
+## 2. Understand the app
+
+This is an Angular 17 app that is also **embeddable** in third-party sites via a
+small `embed.js` loader that runs the app inside an iframe. If your change
+touches the embed, read the README's **Embed** section and test against
+[`embed/example.html`](embed/example.html). Tools are addressed by a hash route
+in the form `/#/{lang}/{book}` (e.g. `/#/en/kgp-us` for "Knowing God Personally").
+
+## 3. Branch and ticket conventions
+
+- **Base branch:** open PRs against `staging` or `main`. CI only runs PR checks
+  (lint, prettier, test, build) on those two branches — a PR against any other
+  base will not be validated.
+- **Title format:** `GT-(JIRA#) (summary, max 80 chars)`. `GT` is the GodTools
+  Jira project prefix. If your work has no ticket, use a short descriptive title.
+- **Commits:** clean up your commit history before requesting review.
+
+## 4. Before opening a PR
+
+Run the same checks CI runs, so you don't round-trip with the pipeline:
+
+```bash
+yarn prettier:write   # auto-format (or prettier:check to only report)
+yarn lint             # lint and auto-fix
+yarn test --no-watch  # unit tests, single run (Karma + Jasmine)
+yarn build            # confirm a production build compiles
+```
+
+A Husky pre-commit hook runs `pretty-quick` on staged files, but running the
+full set above is still the reliable way to match CI.
+
+## 5. Deploying to a test environment
+
+Branch promotion is driven by PR labels (see
+[`.github/workflows/update-staging.yml`](.github/workflows/update-staging.yml)):
+
+- **`On Staging`** — auto-merges your branch into both `staging` and
+  `development`.
+- **`On Development`** — auto-merges into `development` only.
+
+| Environment | URL                          | Deploys from |
+| ----------- | ---------------------------- | ------------ |
+| Production  | https://knowgod.com/en       | `main`       |
+| Staging     | https://stage.knowgod.com/en | `staging`    |
+| Development | https://dev.knowgod.com/en   | `development`|
+| Local       | http://localhost:4200/en     | —            |
+
+## 6. Review
+
+Request a review from another person on the project. There is no `CODEOWNERS`
+file, so if you're new or external and don't know who to tag, ask the team lead
+or whoever assigned you the ticket. For UI or tool-content changes, include
+before/after screenshots or a short screen recording in the PR description so the
+reviewer can verify the visual result quickly.
+
+The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) populates automatically when
+you open a PR — fill out every section and tick the checklist.
+
+## 7. Claude Code plugins (optional but recommended)
+
+This repo ships the shared
+[`CruGlobal/claude-code-plugins`](https://github.com/CruGlobal/claude-code-plugins)
+marketplace in `.claude/settings.json`, so if you use Claude Code the `git`,
+`quality`, `testing`, `admin`, and `figma` plugins are enabled for the project
+automatically (run `/plugin marketplace update` if they don't appear). Useful
+commands include `/quality:pr-review` before requesting review and
+`/testing:test-writer` for new specs. These skills read `CLAUDE.md` in the repo
+root to follow our Angular, testing, and embed conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,17 @@ in the form `/#/{lang}/{book}` (e.g. `/#/en/kgp-us` for "Knowing God Personally"
   Jira project prefix. If your work has no ticket, use a short descriptive title.
 - **Commits:** clean up your commit history before requesting review.
 
-## 4. Before opening a PR
+## 4. Translations (i18n)
+
+All UI strings are English-only in templates and translated via i18next +
+Crowdin. When you add or change a user-facing string, write it with the `i18next`
+pipe (e.g. `{{ 'Tools' | i18next }}`), run `yarn extract`, and commit the updated
+`src/assets/locales/en/translation.json` with your change. Translators and the
+weekly "Update translations" PR are handled automatically. See the
+**[Translations (i18n & Crowdin)](README.md#translations-i18n--crowdin)** section
+of the README for the full flow, setup, and template examples.
+
+## 5. Before opening a PR
 
 Run the same checks CI runs, so you don't round-trip with the pipeline:
 
@@ -43,10 +53,13 @@ yarn test --no-watch  # unit tests, single run (Karma + Jasmine)
 yarn build            # confirm a production build compiles
 ```
 
+If you touched user-facing strings, also run `yarn extract` and commit the
+updated `translation.json`.
+
 A Husky pre-commit hook runs `pretty-quick` on staged files, but running the
 full set above is still the reliable way to match CI.
 
-## 5. Deploying to a test environment
+## 6. Deploying to a test environment
 
 Branch promotion is driven by PR labels (see
 [`.github/workflows/update-staging.yml`](.github/workflows/update-staging.yml)):
@@ -62,7 +75,7 @@ Branch promotion is driven by PR labels (see
 | Development | https://dev.knowgod.com/en   | `development`|
 | Local       | http://localhost:4200/en     | —            |
 
-## 6. Review
+## 7. Review
 
 Request a review from another person on the project. There is no `CODEOWNERS`
 file, so if you're new or external and don't know who to tag, ask the team lead
@@ -73,7 +86,7 @@ reviewer can verify the visual result quickly.
 The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) populates automatically when
 you open a PR — fill out every section and tick the checklist.
 
-## 7. Claude Code plugins (optional but recommended)
+## 8. Claude Code plugins (optional but recommended)
 
 This repo ships the shared
 [`CruGlobal/claude-code-plugins`](https://github.com/CruGlobal/claude-code-plugins)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ the [README](README.md) for the deep detail.
 ## 1. Get set up
 
 Follow the **Getting started** steps in the [README](README.md): install the
-pinned Node version with asdf (`.tool-versions` → Node 20.17.0), confirm Yarn
+pinned Node version with asdf (`.tool-versions` → Node 24.9.0), confirm Yarn
 4.7.0 resolves (enable Corepack if not), run `yarn` to install, then `yarn start`
 (production data) or `yarn start:dev` (staging data) and open
 <http://localhost:4200/en>.
@@ -68,20 +68,25 @@ Branch promotion is driven by PR labels (see
   `development`.
 - **`On Development`** — auto-merges into `development` only.
 
-| Environment | URL                          | Deploys from |
-| ----------- | ---------------------------- | ------------ |
-| Production  | https://knowgod.com/en       | `main`       |
-| Staging     | https://stage.knowgod.com/en | `staging`    |
-| Development | https://dev.knowgod.com/en   | `development`|
-| Local       | http://localhost:4200/en     | —            |
+| Environment | URL                          | Deploys from  |
+| ----------- | ---------------------------- | ------------- |
+| Production  | https://knowgod.com/en       | `main`        |
+| Staging     | https://stage.knowgod.com/en | `staging`     |
+| Development | https://dev.knowgod.com/en   | `development` |
+| Local       | http://localhost:4200/en     | —             |
 
 ## 7. Review
 
-Request a review from another person on the project. There is no `CODEOWNERS`
-file, so if you're new or external and don't know who to tag, ask the team lead
-or whoever assigned you the ticket. For UI or tool-content changes, include
-before/after screenshots or a short screen recording in the PR description so the
-reviewer can verify the visual result quickly.
+Before requesting a review from a human, run `/quality:agent-review` (see
+section 8) and address its findings — this catches the easy stuff and keeps the
+codeowner review focused on substance.
+
+GitHub automatically requests a review from the repo's code owners
+(`.github/CODEOWNERS`) when you open a PR. The PR will need a passing code review
+from one of the codeowners before merging. If you're unsure who to ask, check
+with the team lead or whoever assigned you the ticket. For UI or tool-content
+changes, include before/after screenshots or a short screen recording in the PR
+description so the reviewer can verify the visual result quickly.
 
 The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) populates automatically when
 you open a PR — fill out every section and tick the checklist.
@@ -92,7 +97,7 @@ This repo ships the shared
 [`CruGlobal/claude-code-plugins`](https://github.com/CruGlobal/claude-code-plugins)
 marketplace in `.claude/settings.json`, so if you use Claude Code the `git`,
 `quality`, `testing`, `admin`, and `figma` plugins are enabled for the project
-automatically (run `/plugin marketplace update` if they don't appear). Useful
-commands include `/quality:pr-review` before requesting review and
-`/testing:test-writer` for new specs. These skills read `CLAUDE.md` in the repo
-root to follow our Angular, testing, and embed conventions.
+automatically (run `/plugin marketplace update` if they don't appear). Beyond
+`/quality:agent-review` (covered in section 7), `/testing:test-writer` scaffolds
+new specs for you. These skills read `CLAUDE.md` in the repo root to follow our
+Angular, testing, and embed conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,11 @@ in the form `/#/{lang}/{book}` (e.g. `/#/en/kgp-us` for "Knowing God Personally"
 
 ## 4. Translations (i18n)
 
+> **Status: not yet landed.** The `i18next` pipe, the `yarn extract` script, and
+> `src/assets/locales/` don't exist in the checkout yet — the flow below is the
+> planned process, not a current pre-PR requirement. Skip it until the tooling
+> lands.
+
 All UI strings are English-only in templates and translated via i18next +
 Crowdin. When you add or change a user-facing string, write it with the `i18next`
 pipe (e.g. `{{ 'Tools' | i18next }}`), run `yarn extract`, and commit the updated
@@ -53,11 +58,13 @@ yarn test --no-watch  # unit tests, single run (Karma + Jasmine)
 yarn build            # confirm a production build compiles
 ```
 
-If you touched user-facing strings, also run `yarn extract` and commit the
-updated `translation.json`.
+Once i18n lands (see [§4](#4-translations-i18n)), touching user-facing strings
+will also mean running `yarn extract` and committing the updated
+`translation.json`. That tooling doesn't exist yet, so there's nothing extra to
+run today.
 
-A Husky pre-commit hook runs `pretty-quick` on staged files, but running the
-full set above is still the reliable way to match CI.
+A Husky pre-commit hook runs `yarn lint` and `yarn prettier:check`, but running
+the full set above is still the reliable way to match CI.
 
 ## 6. Deploying to a test environment
 

--- a/README.md
+++ b/README.md
@@ -2,121 +2,392 @@
 
 This is an Angular 17 project created with TypeScript.
 
-## Embed
-
-Add the following snippet to any HTML page to embed a KnowGod.com gospel presentation:
-
-```html
-<div id="knowGodEmbed" data-book="kgp-us" data-lang="en" data-ministry="your-ministry-name"></div>
-<script src="https://knowgod.com/embed.js"></script>
-```
-
-### Data Attributes
-
-| Attribute | Required | Description |
-|---|---|---|
-| `data-book` | Yes | The book/resource identifier (e.g. `kgp-us`, `satisfied`) |
-| `data-lang` | Yes | Language code (e.g. `en`, `es`, `fr`) |
-| `data-ministry` | No | Your ministry identifier. Used for analytics to track which ministries are embedding content. |
-
-The script creates an iframe pointing to `https://knowgod.com/#/{lang}/{book}?embedded=true`. When `data-ministry` is provided, a `&ministry={value}` parameter is appended to the URL so the analytics service can attribute embeds to specific ministries.
-
-### Testing the Embed Locally
-
-A test page is available at `embed/test.html` to verify the embed script works correctly. Start the dev server and open the test page:
-
-```bash
-yarn start
-# then open http://localhost:4200/embed/test.html
-```
-
-The test page uses `window.location.origin` to dynamically point the iframe at the current host, so it works in any environment without needing the `{appDomain}` placeholder that CI/CD replaces in the production `embed.js`.
-
-You can change the `data-book`, `data-lang`, and `data-ministry` values and click **Reload Embed** to test different configurations. The log panel at the bottom shows the generated iframe URL and any `postMessage` height updates received from the embedded content.
-
-## Environments
-
-- Production: https://knowgod.com/en
-- Staging: https://stage.knowgod.com/en
-- Development: https://dev.knowgod.com/en
-- Local: http://localhost:4200/en
-
 ## Development
 
-### Getting Started
+These instructions are written for **macOS** and walk through setting up the
+project from a clean machine. By the end you'll have the app running locally at
+[`http://localhost:4200/en`](http://localhost:4200/en).
 
-First, make sure that you have a suitable version of Node.js. This project uses node v20.17.0. To check your node version, run `node --version`. If you don't have node v20.17.0 installed or a suitable version, the recommended way to install it is with [asdf](https://asdf-vm.com/), a development tool version manager.
+### Prerequisites
 
-You will also need to ensure you are using yarn version `4.7.0`.
+| Tool       | Version    | Why                                        |
+| ---------- | ---------- | ------------------------------------------ |
+| Node.js    | `20.17.0`  | Defined in [`.tool-versions`](.tool-versions) |
+| Yarn       | `4.7.0`    | Package manager (bundled via `.yarn/releases`) |
+| Git        | any recent | Cloning the repo and deploying             |
+| Homebrew   | any recent | Installing asdf                            |
+
+This project pins exact tool versions, so matching them avoids hard-to-debug
+issues. Node is managed with [asdf](https://asdf-vm.com/) and Yarn is committed
+into the repo, so once Node is correct there's nothing extra to install for Yarn.
+
+If you don't already have **Homebrew**, install it first:
 
 ```bash
-# Install asdf and the node plugin
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+### Step 1 — Clone the repository
+
+```bash
+git clone https://github.com/CruGlobal/know-god-web.git
+cd know-god-web
+```
+
+### Step 2 — Install the correct Node version with asdf
+
+This project requires Node `20.17.0`. Check what you have with `node --version`.
+If it doesn't match, install the pinned version with asdf.
+
+```bash
+# Install asdf and the Node plugin
 brew install asdf
 asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 
-# Integrate it with your shell
-# ZSH shell integration is shown here, but for installation instructions for other shells, go to https://asdf-vm.com/guide/getting-started.html#_3-install-asdf
+# Integrate asdf with your shell.
+# ZSH is shown here (the macOS default). For other shells see
+# https://asdf-vm.com/guide/getting-started.html#_3-install-asdf
 echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
-
-# IMPORTANT: Close that terminal tab/window and open another one to apply the changes to your shell configuration file
-
-# Install the version of node defined in this project's .tool-versions file
-asdf install nodejs
-
-# Check that the node version is now 20.17.0
-node --version
 ```
 
-#### Install & Run
+> **Important:** Close that terminal tab/window and open a new one so the shell
+> picks up the asdf configuration before continuing.
 
-Once you're on the correct node version, install the dependencies.
+```bash
+# From inside the repo, install the Node version defined in .tool-versions
+asdf install nodejs
+
+# Confirm you're now on the right version
+node --version   # should print v20.17.0
+```
+
+Because the version is pinned in `.tool-versions`, asdf automatically switches to
+`20.17.0` whenever you `cd` into this project.
+
+### Step 3 — Verify Yarn
+
+Yarn `4.7.0` ships with the repo (see [`.yarnrc.yml`](.yarnrc.yml)), so you don't
+need to install it separately. Confirm it resolves:
+
+```bash
+yarn --version   # should print 4.7.0
+```
+
+If `yarn` isn't found, enable Corepack (included with Node) and retry:
+
+```bash
+corepack enable
+```
+
+### Step 4 — Install dependencies
 
 ```bash
 yarn
 ```
 
-Run the development server:
+This installs all packages and runs the `postinstall` hook, which sets up Husky
+git hooks (used for pre-commit formatting).
+
+### Step 5 — Run the development server
 
 ```bash
 yarn start
 ```
 
-Run `start:dev` if you want to grab data from the staging DB.
+`yarn start` serves the **production** configuration. By default the dev server
+proxies API requests (languages, translations, resources, assets) to Cru's
+production backends — see [`proxy.conf.json`](proxy.conf.json) for the mappings.
 
-Open [`http://localhost:4200`](http://localhost:4200) with your browser to view the site.
+If you'd rather pull data from the **staging** database, run:
+
+```bash
+yarn start:dev
+```
+
+Once the build finishes, open
+[`http://localhost:4200/en`](http://localhost:4200/en) in your browser to view
+the site. The server hot-reloads as you edit files.
+
+### Useful scripts
+
+| Command               | What it does                                            |
+| --------------------- | ------------------------------------------------------- |
+| `yarn start`          | Dev server, production configuration                    |
+| `yarn start:dev`      | Dev server, development configuration (staging data)    |
+| `yarn build`          | Production build                                         |
+| `yarn build:dev`      | Development build                                        |
+| `yarn test`           | Run unit tests once (Karma + Jasmine)                   |
+| `yarn lint`           | Lint and auto-fix `src/**/*.{js,ts,html}`               |
+| `yarn prettier:check` | Report files that aren't formatted                      |
+| `yarn prettier:write` | Format all files                                        |
+
+### Troubleshooting
+
+- **`node --version` doesn't show `20.17.0`** — Make sure you opened a new
+  terminal after the asdf shell integration step, and that you're inside the
+  repo directory so asdf reads `.tool-versions`.
+- **`command not found: yarn`** — Run `corepack enable`, then retry. Yarn is
+  driven by the `yarnPath` in `.yarnrc.yml`, so it only works once Corepack is on.
+- **Install fails on peer-dependency errors** — The repo sets
+  `legacy-peer-deps=true` in `.npmrc`; if you see peer warnings they're expected
+  and non-fatal.
+- **API requests fail locally** — Confirm you started the app with `yarn start`
+  or `yarn start:dev` (not a bare `ng serve`), since the proxy config is wired
+  through those scripts.
+
+## Directory Structure
+
+This is a standard [Angular CLI](https://angular.dev/tools/cli) project, so most
+application code lives under `src/`. The pieces specific to Know God are:
+
+```
+src/
+  app/                 Application root module and components
+    app.module.ts      Root NgModule wiring up the app
+    app.component.*     Root component
+    page/              The main tool renderer — turns a resource into pages
+      component/        Per-content-type components (tract pages, CYOA pages,
+                        cards, paragraphs, links, spacers, etc.)
+      model/            View models for page rendering
+      service/          Page-scoped services
+    dashboard/          Landing/index view
+    services/           App-wide services (analytics, common, loader,
+                        xml-parser) — the XML parser turns GodTools resource
+                        files into renderable content
+    shared/             Reusable helpers and components (loader, sharing modal,
+                        URL/event helpers)
+    api/                API URL definitions (url.ts)
+    _tests/             Shared test mocks (mocks.ts)
+  assets/              Static CSS, fonts (FontAwesome), images, sitemap
+  environments/        Per-environment config (see below)
+  index.html           Host page; contains the embed iframe height-posting script
+  main.ts              Application bootstrap
+  styles.css           Global styles
+
+embed/                 The embeddable loader (embed.js) and a usage example
+mobile/                Mobile deep-linking association files served at
+                       /.well-known/ (Apple app site association, Android assetlinks)
+proxy.conf.json        Dev-server proxy mapping API paths to mobile-content-api
+```
+
+### Configuration & environments
+
+Environment config lives in `src/environments/` rather than a `.env` file:
+
+- `environment.ts` / `environment.development.ts` — local/dev defaults; point at
+  the **staging** mobile-content-api.
+- `environment.prod.ts` — production; points at the production mobile-content-api.
+
+Angular swaps these via the `fileReplacements` in `angular.json` depending on the
+build configuration. During local development, API calls are additionally routed
+through the dev-server proxy defined in `proxy.conf.json`.
+
+## Testing
+
+Unit tests run on [Karma](https://karma-runner.github.io/) with
+[Jasmine](https://jasmine.github.io/), the Angular CLI default. Run the full
+suite once with:
+
+```bash
+yarn test
+```
+
+This executes `ng test --watch=false`, so it runs a single pass and exits — which
+is also what CI runs. To iterate locally with the watcher and the in-browser
+Jasmine HTML reporter, run `yarn ng test` directly.
+
+### Where tests live
+
+Test files sit **next to the code they test**, using the `.spec.ts` suffix. For
+example, the spec for `src/app/services/analytics.service.ts` is
+`src/app/services/analytics.service.spec.ts`, and component specs live alongside
+their components throughout `src/app/page/component/`. Shared test mocks live in
+[`src/app/_tests/mocks.ts`](src/app/_tests/mocks.ts).
+
+### Test runner setup
+
+The runner is configured in [`src/karma.conf.cjs`](src/karma.conf.cjs). A few
+things worth knowing:
+
+- **Headless Chrome.** Tests run in a `ChromeHeadlessNoSandbox` launcher (headless
+  Chrome started with `--no-sandbox`) so they work in CI containers as well as
+  locally. This requires Chrome/Chromium to be installed.
+- **Single run by default.** `singleRun: true` matches the `yarn test` behavior.
+- **Coverage.** A `karma-coverage-istanbul-reporter` writes HTML and `lcov`
+  reports to `coverage/`.
+- **Asset proxy.** Requests to `/assets/` are proxied to `/base/src/assets/` so
+  components that reference static assets resolve correctly under the test server.
+
+### Writing a test
+
+A minimal Angular component spec looks like this:
+
+```ts
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DashboardComponent } from './dashboard.component';
+
+describe('DashboardComponent', () => {
+  let fixture: ComponentFixture<DashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DashboardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DashboardComponent);
+    fixture.detectChanges();
+  });
+
+  it('creates the component', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});
+```
+
+Use Angular's `TestBed` to configure a testing module and render the component,
+then assert against the rendered DOM or the component instance.
+
+## Embed
+
+Any site can drop a Know God tool onto a page with two lines of HTML:
+
+```html
+<div id="knowGodEmbed" data-book="kgp-us" data-lang="en"></div>
+<script src="https://knowgod.com/embed.js"></script>
+```
+
+- `data-book` — the resource/tool to load (e.g. `kgp-us` for "Knowing God Personally").
+- `data-lang` — the language code (e.g. `en`).
+
+A working example lives in [`embed/example.html`](embed/example.html).
+
+### How the embed link works
+
+The `embed.js` script is a small, dependency-free loader. The actual app is
+never injected into the host page directly — instead it runs inside an iframe,
+which keeps Know God's styles and scripts isolated from the host site. Here's the
+full flow:
+
+1. **Find the mount point.** On `window.onload`, the script looks for the
+   `#knowGodEmbed` element. If it isn't found, it logs a message and stops.
+
+2. **Read the attributes.** It pulls `data-book` and `data-lang` off that element.
+
+3. **Build the iframe URL.** It constructs a hash-based URL in the form
+   `{appDomain}/#/{lang}/{book}?embedded=true` and points an iframe at it. The
+   iframe is styled to span 100% width, have no border, and start at a 450px
+   minimum height. The `?embedded=true` query param tells the Angular app it's
+   running embedded (see `page.component.ts`, which sets an `embedded` flag, and
+   `analytics.service.ts`, which tags events as embedded).
+
+4. **`{appDomain}` is environment-specific.** In the repo, `embed.js` ships with
+   a literal `{appDomain}` placeholder. During deploy (see
+   [`.github/workflows/node.js.yml`](.github/workflows/node.js.yml)), the CI
+   pipeline copies `embed/embed.js` into the build output and runs a `sed`
+   replacement that swaps `{appDomain}` for the real host (e.g.
+   `https://knowgod.com`) before uploading it to S3. That's why the production
+   embed script always points at the matching environment.
+
+5. **Auto-resizing (iframe → parent).** Because the app lives in an iframe, the
+   host page can't know how tall the content is. The app handles this from inside
+   the iframe (`src/index.html`): it detects it's embedded (`window.location !==
+   window.parent.location`), then uses a `MutationObserver` to watch for content
+   changes and calls `parent.postMessage(document.body.offsetHeight, '*')`
+   whenever the height changes (with a few delayed re-sends to account for images
+   loading).
+
+6. **Receiving the height (parent → iframe).** `embed.js` registers a `message`
+   listener on the host page. When it receives a numeric height message it sets
+   the iframe's height accordingly, and — if the user has scrolled past the top of
+   the iframe — scrolls back up to keep the tool in view. A `previousHeight` guard
+   prevents redundant updates.
+
+In short: `embed.js` is the lightweight bridge that the host site loads, and the
+real app runs sandboxed in an iframe. The two communicate via `postMessage` so
+the embed grows and shrinks to fit its content automatically.
+
+## Continuous Integration
+
+CI is defined in [`.github/workflows`](.github/workflows). There are two
+workflows.
+
+### `node.js.yml` (CI)
+
+Runs on pushes to `staging`, `development`, and `main`, and on pull requests
+targeting `staging` or `main`. Every job installs dependencies first (Node
+version comes from `.tool-versions`). The four jobs are:
+
+| Job                      | What it checks                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| 🧹 **Lint & Prettier**   | Runs `yarn prettier:check` then `yarn lint` — fails if anything is unformatted or violates lint rules. |
+| ✅ **Tests**             | Runs `yarn test --no-watch` (Karma + Jasmine unit tests, single run).          |
+| 🏗️ **Build app**         | Runs `yarn build` to confirm a production build compiles.                      |
+| 🚀 **Deploy app**        | Only on pushes (not PRs) to `main`/`staging`/`development`. Waits for the three jobs above to pass, builds with the env-matched configuration, injects the host into `embed.js`, copies the `mobile/` directory, and syncs everything to S3. |
+
+The deploy job picks its target environment from the branch: `main` → prod,
+`staging` → stage, `development` → dev. PRs never deploy — they only run lint,
+test, and build.
+
+### `update-staging.yml` (Pipeline)
+
+Automates branch promotion via PR labels (using `devmasx/merge-branch`):
+
+- Add the **`On Staging`** label to a PR to auto-merge that branch into both
+  `staging` and `development`.
+- Add the **`On Development`** label to auto-merge it into `development` only.
+
+This lets you get a branch onto a deployed environment for testing without
+manually merging.
+
+## Before creating a PR
+
+CI will reject unformatted code, lint errors, failing tests, or a broken build,
+so run these locally first to catch problems before pushing. They mirror the CI
+jobs:
+
+```bash
+yarn prettier:write   # auto-format (or `yarn prettier:check` to only report)
+yarn lint             # lint and auto-fix
+yarn test --no-watch  # run unit tests once
+yarn build            # confirm a production build compiles
+```
+
+> A Husky pre-commit hook runs `pretty-quick` on staged files automatically, so
+> formatting is partially enforced on commit — but running the full set above
+> still saves a round-trip with CI.
+
+Open your PR against `staging` or `main` (those are the branches CI runs PR
+checks on). If you want it deployed to a test environment, add the `On Staging`
+or `On Development` label.
+
+## Code review
+
+You don't need to figure out who to tag — a [`.github/CODEOWNERS`](.github/CODEOWNERS)
+file lists the maintainers, and GitHub automatically requests a review from them
+when you open a PR. The current owners are:
+
+- [@kegrimes](https://github.com/kegrimes)
+- [@wjames111](https://github.com/wjames111)
+- [@dr-bizz](https://github.com/dr-bizz)
+- [@canac](https://github.com/canac)
+- [@zweatshirt](https://github.com/zweatshirt)
+
+Merges into `main` are protected: at least **one approving review** is required
+and all CI checks must pass before the PR can merge (this is enforced via branch
+protection managed in the `cru-terraform` repo). If you're a contractor or new
+contributor, just open the PR — the right reviewers are requested automatically.
+To update who the owners are, edit `.github/CODEOWNERS`.
+
+## Environments at a glance
+
+| Environment | URL                            | Deploys from |
+| ----------- | ------------------------------ | ------------ |
+| Production  | https://knowgod.com/en         | `main`       |
+| Staging     | https://stage.knowgod.com/en   | `staging`    |
+| Development | https://dev.knowgod.com/en     | —            |
+| Local       | http://localhost:4200/en       | —            |
 
 ### Deploy
 
 - Push to `staging` to auto-deploy to stage.knowgod.com
 - Push to `main` to auto-deploy to knowgod.com
-
-## Browser Support
-
-Browser and device usage based on GA4 28-day active users for knowgod.com / GodTools (Apr 8 – May 5, 2026).
-
-_Last updated: 2026-05-05; review annually._
-
-**Targeted browsers** (`.browserslistrc`: `> 0.5%, last 2 versions, Firefox ESR, not dead`): the last 2 versions of Chrome, Edge, Firefox (and Firefox ESR), Safari (macOS & iOS), and other evergreen browsers above 0.5% global usage. Internet Explorer is not supported.
-
-**By browser**
-
-| Browser          | Share |
-| :--------------- | :---- |
-| Android Webview  | 50.5% |
-| Chrome           | 36.2% |
-| Safari           | 8.0%  |
-| Samsung Internet | 2.5%  |
-| Edge             | 1.1%  |
-| Other            | <1%   |
-
-**By device**
-
-| Device  | Share |
-| :------ | :---- |
-| Mobile  | 86.5% |
-| Desktop | 13.2% |
-| Tablet  | 0.4%  |
-
-## Documentation
-
-Additional documentation can be found in the `docs/` directory.

--- a/README.md
+++ b/README.md
@@ -1,161 +1,129 @@
-# KnowGod.com embedable web app
+# KnowGod.com embeddable web app
 
-This is an Angular 17 project created with TypeScript.
+An Angular 17 + TypeScript single-page app that renders GodTools resources (e.g.
+"Knowing God Personally", `kgp-us`). It also ships as an **embed**: third-party
+sites load a small `embed.js` loader that runs the app inside an auto-resizing
+iframe. Tools are addressed by hash route — `/#/{lang}/{book}` (e.g. `/#/en/kgp-us`).
 
-## Development
+## Quick start
 
-These instructions are written for **macOS** and walk through setting up the
-project from a clean machine. By the end you'll have the app running locally at
-[`http://localhost:4200/en`](http://localhost:4200/en).
+If you already have Node `24.9.0` and Yarn (via Corepack) set up:
 
-### Prerequisites
+```bash
+git clone https://github.com/CruGlobal/know-god-web.git
+cd know-god-web
+yarn          # install deps + set up Husky hooks
+yarn start    # dev server, production data — http://localhost:4200/en
+```
 
-| Tool     | Version    | Why                                            |
-| -------- | ---------- | ---------------------------------------------- |
-| Node.js  | `24.9.0`   | Defined in [`.tool-versions`](.tool-versions)  |
-| Yarn     | `4.7.0`    | Package manager (bundled via `.yarn/releases`) |
-| Git      | any recent | Cloning the repo and deploying                 |
-| Homebrew | any recent | Installing asdf                                |
+New to the project or starting from a clean machine? See
+[Development setup](#development-setup) for the full macOS walkthrough.
 
-This project pins exact tool versions, so matching them avoids hard-to-debug
-issues. Node is managed with [asdf](https://asdf-vm.com/) and Yarn is committed
-into the repo, so once Node is correct there's nothing extra to install for Yarn.
+## Development setup
 
-If you don't already have **Homebrew**, install it first:
+These steps set up the project from a clean **macOS** machine. The app pins exact
+tool versions, so matching them avoids hard-to-debug issues. Node is managed with
+[asdf](https://asdf-vm.com/); Yarn is committed into the repo, so once Node is
+correct there's nothing extra to install for Yarn — just
+[enable Corepack](https://yarnpkg.com/corepack).
+
+| Tool     | Version  | Why                                           |
+| -------- | -------- | --------------------------------------------- |
+| Node.js  | `24.9.0` | Defined in [`.tool-versions`](.tool-versions) |
+| Yarn     | `4.7.0`  | Committed via `.yarn/releases`; run via Corepack |
+| Git      | recent   | Cloning and deploying                         |
+| Homebrew | recent   | Installs asdf                                 |
+
+**1. Install Homebrew** (skip if you have it):
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
-### Step 1 — Clone the repository
+**2. Install Node `24.9.0` with asdf:**
 
 ```bash
-git clone https://github.com/CruGlobal/know-god-web.git
-cd know-god-web
-```
-
-### Step 2 — Install the correct Node version with asdf
-
-This project requires Node `24.9.0`. Check what you have with `node --version`.
-If it doesn't match, install the pinned version with asdf.
-
-```bash
-# Install asdf and the Node plugin
 brew install asdf
 asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 
-# Integrate asdf with your shell.
-# ZSH is shown here (the macOS default). For other shells see
-# https://asdf-vm.com/guide/getting-started.html#_3-install-asdf
+# Integrate asdf with your shell (ZSH shown — the macOS default; for others see
+# https://asdf-vm.com/guide/getting-started.html#_3-install-asdf)
 echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
 ```
 
-> **Important:** Close that terminal tab/window and open a new one so the shell
-> picks up the asdf configuration before continuing.
+Open a **new** terminal so the shell picks up asdf, then from inside the repo:
 
 ```bash
-# From inside the repo, install the Node version defined in .tool-versions
-asdf install nodejs
-
-# Confirm you're now on the right version
-node --version   # should print v24.9.0
+asdf install nodejs   # installs the version from .tool-versions
+node --version        # should print v24.9.0
 ```
 
-Because the version is pinned in `.tool-versions`, asdf automatically switches to
-`24.9.0` whenever you `cd` into this project.
+asdf auto-switches to `24.9.0` whenever you `cd` into the project.
 
-### Step 3 — Verify Yarn
-
-Yarn `4.7.0` ships with the repo (see [`.yarnrc.yml`](.yarnrc.yml)), so you don't
-need to install it separately. Confirm it resolves:
+**3. Enable Yarn and install dependencies:**
 
 ```bash
-yarn --version   # should print 4.7.0
+corepack enable   # turns on the repo's pinned Yarn 4.7.0
+yarn --version    # should print 4.7.0
+yarn              # installs packages + runs postinstall (Husky git hooks)
 ```
 
-If `yarn` isn't found, enable Corepack (included with Node) and retry:
+**4. Run the dev server:**
 
 ```bash
-corepack enable
+yarn start        # serves the PRODUCTION config (proxies to prod backends)
+# or
+yarn start:dev    # serves staging data
 ```
 
-### Step 4 — Install dependencies
+Open [`http://localhost:4200/en`](http://localhost:4200/en). The server
+hot-reloads on edit. Local API calls are routed through the dev-server proxy in
+[`proxy.conf.json`](proxy.conf.json) — so always start via `yarn start` /
+`yarn start:dev`, never a bare `ng serve`.
 
-```bash
-yarn
-```
-
-This installs all packages and runs the `postinstall` hook, which sets up Husky
-git hooks (used for pre-commit formatting).
-
-### Step 5 — Run the development server
-
-```bash
-yarn start
-```
-
-`yarn start` serves the **production** configuration. By default the dev server
-proxies API requests (languages, translations, resources, assets) to Cru's
-production backends — see [`proxy.conf.json`](proxy.conf.json) for the mappings.
-
-If you'd rather pull data from the **staging** database, run:
-
-```bash
-yarn start:dev
-```
-
-Once the build finishes, open
-[`http://localhost:4200/en`](http://localhost:4200/en) in your browser to view
-the site. The server hot-reloads as you edit files.
-
-### Useful scripts
+### Scripts
 
 | Command               | What it does                                         |
 | --------------------- | ---------------------------------------------------- |
-| `yarn start`          | Dev server, production configuration                 |
-| `yarn start:dev`      | Dev server, development configuration (staging data) |
+| `yarn start`          | Dev server, production config                        |
+| `yarn start:dev`      | Dev server, development config (staging data)        |
 | `yarn build`          | Production build                                     |
 | `yarn build:dev`      | Development build                                    |
-| `yarn test`           | Run unit tests once (Karma + Jasmine)                |
+| `yarn test`           | Run unit tests once (Karma + Jasmine, single pass)   |
 | `yarn lint`           | Lint and auto-fix `src/**/*.{js,ts,html}`            |
 | `yarn prettier:check` | Report files that aren't formatted                   |
 | `yarn prettier:write` | Format all files                                     |
 
 ### Troubleshooting
 
-- **`node --version` doesn't show `24.9.0`** — Make sure you opened a new
-  terminal after the asdf shell integration step, and that you're inside the
-  repo directory so asdf reads `.tool-versions`.
+- **`node --version` isn't `24.9.0`** — Open a new terminal after the asdf shell
+  integration step, and make sure you're inside the repo so asdf reads
+  `.tool-versions`.
 - **`command not found: yarn`** — Run `corepack enable`, then retry. Yarn is
-  driven by the `yarnPath` in `.yarnrc.yml`, so it only works once Corepack is on.
-- **Install fails on peer-dependency errors** — The repo sets
-  `legacy-peer-deps=true` in `.npmrc`; if you see peer warnings they're expected
-  and non-fatal.
-- **API requests fail locally** — Confirm you started the app with `yarn start`
-  or `yarn start:dev` (not a bare `ng serve`), since the proxy config is wired
-  through those scripts.
+  driven by `yarnPath` in [`.yarnrc.yml`](.yarnrc.yml) and only resolves once
+  Corepack is on.
+- **Peer-dependency errors on install** — `.npmrc` sets `legacy-peer-deps=true`;
+  peer warnings are expected and non-fatal.
+- **API requests fail locally** — Start via `yarn start` / `yarn start:dev` so the
+  proxy config is loaded.
 
-## Directory Structure
+## Project structure
 
-This is a standard [Angular CLI](https://angular.dev/tools/cli) project, so most
-application code lives under `src/`. The pieces specific to Know God are:
+A standard [Angular CLI](https://angular.dev/tools/cli) project; most code lives
+under `src/`. The Know God–specific pieces:
 
 ```
 src/
-  app/                 Application root module and components
-    app.module.ts      Root NgModule wiring up the app
-    app.component.*     Root component
-    page/              The main tool renderer — turns a resource into pages
-      component/        Per-content-type components (tract pages, CYOA pages,
-                        cards, paragraphs, links, spacers, etc.)
-      model/            View models for page rendering
-      service/          Page-scoped services
+  app/
+    app.module.ts       Root NgModule (routing wired here; not standalone)
+    page/               The tool renderer — turns a resource into pages
+      component/         Per-content-type components (tract & CYOA pages, cards,
+                         paragraphs, links, spacers, etc.)
+      model/             View models for page rendering
+      service/           Page-scoped services (e.g. PageService)
     dashboard/          Landing/index view
-    services/           App-wide services (analytics, common, loader,
-                        xml-parser) — the XML parser turns GodTools resource
-                        files into renderable content
-    shared/             Reusable helpers and components (loader, sharing modal,
-                        URL/event helpers)
+    services/           App-wide services (analytics, common, loader, xml-parser)
+    shared/             Reusable helpers and components (loader, sharing modal)
     api/                API URL definitions (url.ts)
     _tests/             Shared test mocks (mocks.ts)
   assets/              Static CSS, fonts (FontAwesome), images, sitemap
@@ -165,62 +133,33 @@ src/
   styles.css           Global styles
 
 embed/                 The embeddable loader (embed.js) and a usage example
-mobile/                Mobile deep-linking association files served at
-                       /.well-known/ (Apple app site association, Android assetlinks)
+mobile/                Deep-linking association files served at /.well-known/
 proxy.conf.json        Dev-server proxy mapping API paths to mobile-content-api
 ```
 
-### Configuration & environments
+**Environments.** Config lives in `src/environments/`, not a `.env` file.
+`environment.ts` / `environment.development.ts` point at the **staging**
+mobile-content-api; `environment.prod.ts` points at **production**. Angular swaps
+them via `fileReplacements` in `angular.json` per build configuration. (Locally,
+API calls also pass through the dev-server proxy.)
 
-Environment config lives in `src/environments/` rather than a `.env` file:
-
-- `environment.ts` / `environment.development.ts` — local/dev defaults; point at
-  the **staging** mobile-content-api.
-- `environment.prod.ts` — production; points at the production mobile-content-api.
-
-Angular swaps these via the `fileReplacements` in `angular.json` depending on the
-build configuration. During local development, API calls are additionally routed
-through the dev-server proxy defined in `proxy.conf.json`.
+Content is parsed by `XmlParserService`, which wraps
+`@cruglobal/godtools-shared` — see [`docs/parser.md`](docs/parser.md).
 
 ## Testing
 
-Unit tests run on [Karma](https://karma-runner.github.io/) with
-[Jasmine](https://jasmine.github.io/), the Angular CLI default. Run the full
-suite once with:
+Unit tests run on [Karma](https://karma-runner.github.io/) +
+[Jasmine](https://jasmine.github.io/) in headless Chrome (the
+`ChromeHeadlessNoSandbox` launcher, so they work in CI containers — Chrome must be
+installed). Run the full suite once with `yarn test` (this is what CI runs). To
+iterate with the watcher and Jasmine HTML reporter, run `yarn ng test` directly.
 
-```bash
-yarn test
-```
+The runner is configured in [`src/karma.conf.cjs`](src/karma.conf.cjs) (single
+run, Istanbul coverage to `coverage/`, `/assets/` proxied to `/base/src/assets/`).
 
-This executes `ng test --watch=false`, so it runs a single pass and exits — which
-is also what CI runs. To iterate locally with the watcher and the in-browser
-Jasmine HTML reporter, run `yarn ng test` directly.
-
-### Where tests live
-
-Test files sit **next to the code they test**, using the `.spec.ts` suffix. For
-example, the spec for `src/app/services/analytics.service.ts` is
-`src/app/services/analytics.service.spec.ts`, and component specs live alongside
-their components throughout `src/app/page/component/`. Shared test mocks live in
-[`src/app/_tests/mocks.ts`](src/app/_tests/mocks.ts).
-
-### Test runner setup
-
-The runner is configured in [`src/karma.conf.cjs`](src/karma.conf.cjs). A few
-things worth knowing:
-
-- **Headless Chrome.** Tests run in a `ChromeHeadlessNoSandbox` launcher (headless
-  Chrome started with `--no-sandbox`) so they work in CI containers as well as
-  locally. This requires Chrome/Chromium to be installed.
-- **Single run by default.** `singleRun: true` matches the `yarn test` behavior.
-- **Coverage.** A `karma-coverage-istanbul-reporter` writes HTML and `lcov`
-  reports to `coverage/`.
-- **Asset proxy.** Requests to `/assets/` are proxied to `/base/src/assets/` so
-  components that reference static assets resolve correctly under the test server.
-
-### Writing a test
-
-A minimal Angular component spec looks like this:
+Specs sit **next to the code they test** with a `.spec.ts` suffix (e.g.
+`analytics.service.spec.ts` beside `analytics.service.ts`). Shared mocks live in
+[`src/app/_tests/mocks.ts`](src/app/_tests/mocks.ts). A minimal component spec:
 
 ```ts
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -233,7 +172,6 @@ describe('DashboardComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [DashboardComponent]
     }).compileComponents();
-
     fixture = TestBed.createComponent(DashboardComponent);
     fixture.detectChanges();
   });
@@ -244,12 +182,10 @@ describe('DashboardComponent', () => {
 });
 ```
 
-Use Angular's `TestBed` to configure a testing module and render the component,
-then assert against the rendered DOM or the component instance.
-
 ## Embed
 
-Add the following snippet to any HTML page to embed a KnowGod.com gospel presentation:
+Add this snippet to any HTML page to embed a KnowGod.com gospel presentation. A
+working example is in [`embed/example.html`](embed/example.html).
 
 ```html
 <div
@@ -261,243 +197,89 @@ Add the following snippet to any HTML page to embed a KnowGod.com gospel present
 <script src="https://knowgod.com/embed.js"></script>
 ```
 
-### Data Attributes
+| Attribute       | Required | Description                                             |
+| --------------- | -------- | ------------------------------------------------------- |
+| `data-book`     | Yes      | Resource identifier (e.g. `kgp-us`, `satisfied`)        |
+| `data-lang`     | Yes      | Language code (e.g. `en`, `es`, `fr`)                   |
+| `data-ministry` | No       | Ministry identifier; used by analytics to attribute embeds |
 
-| Attribute       | Required | Description                                                                                   |
-| --------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `data-book`     | Yes      | The book/resource identifier (e.g. `kgp-us`, `satisfied`)                                     |
-| `data-lang`     | Yes      | Language code (e.g. `en`, `es`, `fr`)                                                         |
-| `data-ministry` | No       | Your ministry identifier. Used for analytics to track which ministries are embedding content. |
+### How it works
 
-The script creates an iframe pointing to `https://knowgod.com/#/{lang}/{book}?embedded=true`. When `data-ministry` is provided, a `&ministry={value}` parameter is appended to the URL so the analytics service can attribute embeds to specific ministries.
+`embed.js` is a small, dependency-free loader. The app is **never** injected into
+the host page — it runs inside an iframe so Know God's styles and scripts stay
+isolated from the host site. They communicate via `postMessage`:
 
-### Testing the Embed Locally
+1. On `window.onload`, the loader finds `#knowGodEmbed` and reads its
+   `data-*` attributes.
+2. It builds the iframe URL `{appDomain}/#/{lang}/{book}?embedded=true` (plus
+   `&ministry={value}` when supplied) and inserts an iframe styled to full width,
+   no border, 450px minimum height. `?embedded=true` tells the app it's embedded —
+   see the `embedded` flag in `page.component.ts` and the embedded tagging in
+   `analytics.service.ts`.
+3. `{appDomain}` is a placeholder in the repo; during deploy CI runs a `sed`
+   replacement to point it at the matching host (e.g. `https://knowgod.com`).
+4. **Auto-resize (iframe → parent):** the app detects it's embedded
+   (`window.location !== window.parent.location`) and uses a `MutationObserver`
+   to `parent.postMessage(document.body.offsetHeight, '*')` on height changes —
+   see [`src/index.html`](src/index.html).
+5. **Receiving height (parent → iframe):** `embed.js` listens for numeric height
+   messages, sets the iframe height, and scrolls the tool back into view if
+   needed (a `previousHeight` guard skips redundant updates).
 
-A test page is available at `embed/test.html` to verify the embed script works correctly. Start the dev server and open the test page:
+### Testing the embed locally
 
 ```bash
 yarn start
 # then open http://localhost:4200/embed/test.html
 ```
 
-The test page uses `window.location.origin` to dynamically point the iframe at the current host, so it works in any environment without needing the `{appDomain}` placeholder that CI/CD replaces in the production `embed.js`.
-
-You can change the `data-book`, `data-lang`, and `data-ministry` values and click **Reload Embed** to test different configurations. The log panel at the bottom shows the generated iframe URL and any `postMessage` height updates received from the embedded content.
-
-## Environments
-
-A working example lives in [`embed/example.html`](embed/example.html).
-
-### How the embed link works
-
-The `embed.js` script is a small, dependency-free loader. The actual app is
-never injected into the host page directly — instead it runs inside an iframe,
-which keeps Know God's styles and scripts isolated from the host site. Here's the
-full flow:
-
-1. **Find the mount point.** On `window.onload`, the script looks for the
-   `#knowGodEmbed` element. If it isn't found, it logs a message and stops.
-
-2. **Read the attributes.** It pulls `data-book` and `data-lang` off that element.
-
-3. **Build the iframe URL.** It constructs a hash-based URL in the form
-   `{appDomain}/#/{lang}/{book}?embedded=true` and points an iframe at it. The
-   iframe is styled to span 100% width, have no border, and start at a 450px
-   minimum height. The `?embedded=true` query param tells the Angular app it's
-   running embedded (see `page.component.ts`, which sets an `embedded` flag, and
-   `analytics.service.ts`, which tags events as embedded).
-
-4. **`{appDomain}` is environment-specific.** In the repo, `embed.js` ships with
-   a literal `{appDomain}` placeholder. During deploy (see
-   [`.github/workflows/node.js.yml`](.github/workflows/node.js.yml)), the CI
-   pipeline copies `embed/embed.js` into the build output and runs a `sed`
-   replacement that swaps `{appDomain}` for the real host (e.g.
-   `https://knowgod.com`) before uploading it to S3. That's why the production
-   embed script always points at the matching environment.
-
-5. **Auto-resizing (iframe → parent).** Because the app lives in an iframe, the
-   host page can't know how tall the content is. The app handles this from inside
-   the iframe (`src/index.html`): it detects it's embedded (`window.location !==
-window.parent.location`), then uses a `MutationObserver` to watch for content
-   changes and calls `parent.postMessage(document.body.offsetHeight, '*')`
-   whenever the height changes (with a few delayed re-sends to account for images
-   loading).
-
-6. **Receiving the height (parent → iframe).** `embed.js` registers a `message`
-   listener on the host page. When it receives a numeric height message it sets
-   the iframe's height accordingly, and — if the user has scrolled past the top of
-   the iframe — scrolls back up to keep the tool in view. A `previousHeight` guard
-   prevents redundant updates.
-
-In short: `embed.js` is the lightweight bridge that the host site loads, and the
-real app runs sandboxed in an iframe. The two communicate via `postMessage` so
-the embed grows and shrinks to fit its content automatically.
+[`embed/test.html`](embed/test.html) points the iframe at
+`window.location.origin`, so it works in any environment without the `{appDomain}`
+replacement. Change `data-book` / `data-lang` / `data-ministry` and click **Reload
+Embed**; the log panel shows the generated URL and incoming height updates.
 
 ## Translations (i18n & Crowdin)
 
-> **Status:** This translation tooling is being rolled out. If the files,
-> scripts, or workflows referenced below aren't present in your checkout yet,
-> they're still landing — this section documents the intended workflow.
+> **Status: not yet landed.** UI-string translation via
+> [i18next](https://www.i18next.com/) + [Crowdin](https://crowdin.com/) is
+> planned; the files and scripts below don't exist in the checkout yet. This
+> documents the intended workflow.
 
-UI strings are translated with [i18next](https://www.i18next.com/) and managed in
-[Crowdin](https://crowdin.com/). Developers only ever write **English** strings in
-templates; everything else (extraction, upload, translator hand-off, and the
-return PR) is automated.
+Developers only write **English** strings in templates with the `i18next` pipe;
+extraction, upload, and the translation-return PR are automated:
 
-### Main flow
+1. Write a string: `{{ 'Tools' | i18next }}` (or with a value:
+   `{{ '1994-{{ year }} Cru.' | i18next: { year: currentYear } }}`). The key
+   **is** the full English string.
+2. `yarn extract` writes keys into `src/assets/locales/en/translation.json`;
+   commit it with your change.
+3. On merge to `main`, English strings upload to Crowdin.
+4. A scheduled job downloads translations weekly and opens an **"Update
+   translations"** PR for the UI team to review.
 
-1. A developer writes a string in a template using the `i18next` pipe:
-   `{{ 'Tools' | i18next }}`.
-2. `yarn extract` scans the code and writes the keys into
-   `src/assets/locales/en/translation.json`.
-3. When changes are merged to `main`, the English strings are uploaded to
-   Crowdin for translators.
-4. Every **Monday at 5:50am EST**, translations are downloaded from Crowdin,
-   sorted, and a PR titled **"Update translations"** is opened automatically.
-5. The UI team reviews and approves that PR.
+Crowdin project ID `897600` _(temporary)_; `CROWDIN_API_TOKEN` lives in the
+repo's GitHub Actions secrets.
 
-### One-time setup (installing the tooling)
+## CI, deployment & environments
 
-This repo uses **Yarn** — use the `yarn add` commands below (the `npm` equivalents
-are shown for reference only; don't run `npm install` here, as it would create a
-conflicting `package-lock.json`).
+CI is defined in [`.github/workflows`](.github/workflows).
 
-```bash
-# Runtime dependencies
-yarn add i18next i18next-browser-languagedetector i18next-http-backend angular-i18next
-# Dev dependency: the extractor
-yarn add --dev i18next-parser
-# Crowdin CLI
-yarn add crowdin @crowdin/cli
+**`node.js.yml`** runs on pushes to `staging` / `development` / `main` and on PRs
+targeting `staging` or `main`. Every job installs deps first (Node from
+`.tool-versions`):
 
-# npm equivalents (reference only):
-#   npm install i18next i18next-browser-languagedetector i18next-http-backend angular-i18next
-#   npm install --save-dev i18next-parser
-#   npm install crowdin @crowdin/cli
-```
+| Job                  | Checks                                                              |
+| -------------------- | ------------------------------------------------------------------ |
+| 🧹 Lint & Prettier   | `yarn prettier:check` then `yarn lint`                             |
+| ✅ Tests             | `yarn test` (single Karma + Jasmine run)                          |
+| 🏗️ Build app         | `yarn build` — confirms a production build compiles                |
+| 🚀 Deploy app        | Pushes only (never PRs). Builds the env-matched config, injects the host into `embed.js`, copies `mobile/`, and syncs to S3 |
 
-### Crowdin project
+**`update-staging.yml`** promotes branches via PR labels: **`On Staging`**
+auto-merges into both `staging` and `development`; **`On Development`** merges into
+`development` only.
 
-- **Project ID:** `897600` _(temporary — to be migrated to a new project owned by
-  Daniel Frett)._
-- **`CROWDIN_API_TOKEN`** is created in the Crowdin project and stored as a GitHub
-  Actions repository secret at
-  [Settings → Secrets → Actions](https://github.com/CruGlobal/know-god-web/settings/secrets/actions).
-
-### Files and what they do
-
-| File                                     | Purpose                                                                                                              |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `src/app/i18n.ts`                        | Starts up i18next when the app loads                                                                                 |
-| `src/app/app.module.ts`                  | Registers i18next with Angular so the `i18next` pipe works in templates                                              |
-| `i18next-parser.config.cjs`              | Config for `yarn extract`; a custom lexer matches the `'key' \| i18next` pattern in HTML and extracts the key        |
-| `crowdin/sort-translations.cjs`          | Alphabetically sorts every locale's `translation.json`                                                               |
-| `src/assets/locales/en/translation.json` | The generated English source file                                                                                    |
-| `crowdin.yml`                            | Crowdin project config — which file is the source, where translations go, and who reviews the auto-PRs               |
-| `.github/workflows/node.js.yml`          | Adds a translation job to CI so every PR runs `yarn extract`                                                         |
-| `.github/workflows/crowdin.yml`          | Scheduled job that extracts, downloads translations from Crowdin, sorts them, and opens the "Update translations" PR |
-
-### Using it in templates
-
-The key **is the full English string**. Simple string:
-
-```html
-{{ 'Tools' | i18next }}
-```
-
-String with a dynamic value:
-
-```html
-{{ '1994-{{ year }} Cru. All Rights Reserved.' | i18next: { year: currentYear }
-}}
-```
-
-These produce the following entries in `translation.json` (keys are the full
-English text):
-
-```json
-{
-  "Tools": "Tools",
-  "1994-{{ year }} Cru. All Rights Reserved.": "1994-{{ year }} Cru. All Rights Reserved."
-}
-```
-
-After adding or changing strings, run `yarn extract` and commit the updated
-`translation.json` along with your change.
-
-## Continuous Integration
-
-CI is defined in [`.github/workflows`](.github/workflows). There are two
-workflows.
-
-### `node.js.yml` (CI)
-
-Runs on pushes to `staging`, `development`, and `main`, and on pull requests
-targeting `staging` or `main`. Every job installs dependencies first (Node
-version comes from `.tool-versions`). The four jobs are:
-
-| Job                    | What it checks                                                                                                                                                                                                                               |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🧹 **Lint & Prettier** | Runs `yarn prettier:check` then `yarn lint` — fails if anything is unformatted or violates lint rules.                                                                                                                                       |
-| ✅ **Tests**           | Runs `yarn test --no-watch` (Karma + Jasmine unit tests, single run).                                                                                                                                                                        |
-| 🏗️ **Build app**       | Runs `yarn build` to confirm a production build compiles.                                                                                                                                                                                    |
-| 🚀 **Deploy app**      | Only on pushes (not PRs) to `main`/`staging`/`development`. Waits for the three jobs above to pass, builds with the env-matched configuration, injects the host into `embed.js`, copies the `mobile/` directory, and syncs everything to S3. |
-
-The deploy job picks its target environment from the branch: `main` → prod,
-`staging` → stage, `development` → dev. PRs never deploy — they only run lint,
-test, and build.
-
-### `update-staging.yml` (Pipeline)
-
-Automates branch promotion via PR labels (using `devmasx/merge-branch`):
-
-- Add the **`On Staging`** label to a PR to auto-merge that branch into both
-  `staging` and `development`.
-- Add the **`On Development`** label to auto-merge it into `development` only.
-
-This lets you get a branch onto a deployed environment for testing without
-manually merging.
-
-## Before creating a PR
-
-CI will reject unformatted code, lint errors, failing tests, or a broken build,
-so run these locally first to catch problems before pushing. They mirror the CI
-jobs:
-
-```bash
-yarn prettier:write   # auto-format (or `yarn prettier:check` to only report)
-yarn lint             # lint and auto-fix
-yarn test --no-watch  # run unit tests once
-yarn build            # confirm a production build compiles
-```
-
-> A Husky pre-commit hook runs `pretty-quick` on staged files automatically, so
-> formatting is partially enforced on commit — but running the full set above
-> still saves a round-trip with CI.
-
-Open your PR against `staging` or `main` (those are the branches CI runs PR
-checks on). If you want it deployed to a test environment, add the `On Staging`
-or `On Development` label.
-
-## Code review
-
-You don't need to figure out who to tag — a [`.github/CODEOWNERS`](.github/CODEOWNERS)
-file lists the maintainers, and GitHub automatically requests a review from them
-when you open a PR. The current owners are:
-
-- [@kegrimes](https://github.com/kegrimes)
-- [@wjames111](https://github.com/wjames111)
-- [@dr-bizz](https://github.com/dr-bizz)
-- [@canac](https://github.com/canac)
-- [@zweatshirt](https://github.com/zweatshirt)
-
-Merges into `main` are protected: at least **one approving review** is required
-and all CI checks must pass before the PR can merge (this is enforced via branch
-protection managed in the `cru-terraform` repo). If you're a contractor or new
-contributor, just open the PR — the right reviewers are requested automatically.
-To update who the owners are, edit `.github/CODEOWNERS`.
-
-## Environments at a glance
+Branch → environment:
 
 | Environment | URL                          | Deploys from |
 | ----------- | ---------------------------- | ------------ |
@@ -506,11 +288,31 @@ To update who the owners are, edit `.github/CODEOWNERS`.
 | Development | https://dev.knowgod.com/en   | —            |
 | Local       | http://localhost:4200/en     | —            |
 
-### Deploy
+## Before creating a PR
 
-- Push to `staging` to auto-deploy to stage.knowgod.com
-- Push to `main` to auto-deploy to knowgod.com
+Run the four checks that mirror CI to avoid a round-trip:
+
+```bash
+yarn prettier:write   # auto-format (or prettier:check to only report)
+yarn lint             # lint and auto-fix
+yarn test             # run unit tests once
+yarn build            # confirm a production build compiles
+```
+
+A Husky pre-commit hook runs `pretty-quick` on staged files, but the full set
+above still catches more. Open your PR against **`staging`** or **`main`** (the
+branches CI runs PR checks on); add the `On Staging` / `On Development` label to
+deploy it to a test environment.
+
+### Code review
+
+[`.github/CODEOWNERS`](.github/CODEOWNERS) lists the maintainers, and GitHub
+auto-requests their review when you open a PR — you don't need to tag anyone.
+Merges into `main` require at least **one approving review** and passing CI
+(enforced via branch protection in `cru-terraform`). New contributors and
+contractors: just open the PR; the right reviewers are requested automatically.
 
 ## Documentation
 
-Additional documentation can be found in the `docs/` directory.
+Further docs live in [`docs/`](docs/) — see
+[`docs/parser.md`](docs/parser.md) for the GodTools XML parser.

--- a/README.md
+++ b/README.md
@@ -317,6 +317,33 @@ Merges into `main` require at least **one approving review** and passing CI
 (enforced via branch protection in `cru-terraform`). New contributors and
 contractors: just open the PR; the right reviewers are requested automatically.
 
+## Browser Support
+
+Browser and device usage based on GA4 28-day active users for knowgod.com / GodTools (Apr 8 – May 5, 2026).
+
+_Last updated: 2026-05-05; review annually._
+
+**Targeted browsers** (`.browserslistrc`: `> 0.5%, last 2 versions, Firefox ESR, not dead`): the last 2 versions of Chrome, Edge, Firefox (and Firefox ESR), Safari (macOS & iOS), and other evergreen browsers above 0.5% global usage. Internet Explorer is not supported.
+
+**By browser**
+
+| Browser          | Share |
+| :--------------- | :---- |
+| Android Webview  | 50.5% |
+| Chrome           | 36.2% |
+| Safari           | 8.0%  |
+| Samsung Internet | 2.5%  |
+| Edge             | 1.1%  |
+| Other            | <1%   |
+
+**By device**
+
+| Device  | Share |
+| :------ | :---- |
+| Mobile  | 86.5% |
+| Desktop | 13.2% |
+| Tablet  | 0.4%  |
+
 ## Documentation
 
 Further docs live in [`docs/`](docs/) — see

--- a/README.md
+++ b/README.md
@@ -306,6 +306,97 @@ In short: `embed.js` is the lightweight bridge that the host site loads, and the
 real app runs sandboxed in an iframe. The two communicate via `postMessage` so
 the embed grows and shrinks to fit its content automatically.
 
+## Translations (i18n & Crowdin)
+
+> **Status:** This translation tooling is being rolled out. If the files,
+> scripts, or workflows referenced below aren't present in your checkout yet,
+> they're still landing — this section documents the intended workflow.
+
+UI strings are translated with [i18next](https://www.i18next.com/) and managed in
+[Crowdin](https://crowdin.com/). Developers only ever write **English** strings in
+templates; everything else (extraction, upload, translator hand-off, and the
+return PR) is automated.
+
+### Main flow
+
+1. A developer writes a string in a template using the `i18next` pipe:
+   `{{ 'Tools' | i18next }}`.
+2. `yarn extract` scans the code and writes the keys into
+   `src/assets/locales/en/translation.json`.
+3. When changes are merged to `main`, the English strings are uploaded to
+   Crowdin for translators.
+4. Every **Monday at 5:50am EST**, translations are downloaded from Crowdin,
+   sorted, and a PR titled **"Update translations"** is opened automatically.
+5. The UI team reviews and approves that PR.
+
+### One-time setup (installing the tooling)
+
+This repo uses **Yarn** — use the `yarn add` commands below (the `npm` equivalents
+are shown for reference only; don't run `npm install` here, as it would create a
+conflicting `package-lock.json`).
+
+```bash
+# Runtime dependencies
+yarn add i18next i18next-browser-languagedetector i18next-http-backend angular-i18next
+# Dev dependency: the extractor
+yarn add --dev i18next-parser
+# Crowdin CLI
+yarn add crowdin @crowdin/cli
+
+# npm equivalents (reference only):
+#   npm install i18next i18next-browser-languagedetector i18next-http-backend angular-i18next
+#   npm install --save-dev i18next-parser
+#   npm install crowdin @crowdin/cli
+```
+
+### Crowdin project
+
+- **Project ID:** `897600` _(temporary — to be migrated to a new project owned by
+  Sway Ciaramello)._
+- **`CROWDIN_API_TOKEN`** is created in the Crowdin project and stored as a GitHub
+  Actions repository secret at
+  [Settings → Secrets → Actions](https://github.com/CruGlobal/know-god-web/settings/secrets/actions).
+
+### Files and what they do
+
+| File | Purpose |
+| --- | --- |
+| `src/app/i18n.ts` | Starts up i18next when the app loads |
+| `src/app/app.module.ts` | Registers i18next with Angular so the `i18next` pipe works in templates |
+| `i18next-parser.config.cjs` | Config for `yarn extract`; a custom lexer matches the `'key' \| i18next` pattern in HTML and extracts the key |
+| `crowdin/sort-translations.cjs` | Alphabetically sorts every locale's `translation.json` |
+| `src/assets/locales/en/translation.json` | The generated English source file |
+| `crowdin.yml` | Crowdin project config — which file is the source, where translations go, and who reviews the auto-PRs |
+| `.github/workflows/node.js.yml` | Adds a translation job to CI so every PR runs `yarn extract` |
+| `.github/workflows/crowdin.yml` | Scheduled job that extracts, downloads translations from Crowdin, sorts them, and opens the "Update translations" PR |
+
+### Using it in templates
+
+The key **is the full English string**. Simple string:
+
+```html
+{{ 'Tools' | i18next }}
+```
+
+String with a dynamic value:
+
+```html
+{{ '1994-{{ year }} Cru. All Rights Reserved.' | i18next: { year: currentYear } }}
+```
+
+These produce the following entries in `translation.json` (keys are the full
+English text):
+
+```json
+{
+  "Tools": "Tools",
+  "1994-{{ year }} Cru. All Rights Reserved.": "1994-{{ year }} Cru. All Rights Reserved."
+}
+```
+
+After adding or changing strings, run `yarn extract` and commit the updated
+`translation.json` along with your change.
+
 ## Continuous Integration
 
 CI is defined in [`.github/workflows`](.github/workflows). There are two

--- a/README.md
+++ b/README.md
@@ -281,11 +281,11 @@ auto-merges into both `staging` and `development`; **`On Development`** merges i
 
 Branch → environment:
 
-| Environment | URL                          | Deploys from |
-| ----------- | ---------------------------- | ------------ |
-| Production  | https://knowgod.com/en       | `main`       |
-| Staging     | https://stage.knowgod.com/en | `staging`    |
-| Development | https://dev.knowgod.com/en   | —            |
+| Environment | URL                          | Deploys from  |
+| ----------- | ---------------------------- | ------------- |
+| Production  | https://knowgod.com/en       | `main`        |
+| Staging     | https://stage.knowgod.com/en | `staging`     |
+| Development | https://dev.knowgod.com/en   | `development` |
 | Local       | http://localhost:4200/en     | —            |
 
 ## Before creating a PR
@@ -299,8 +299,8 @@ yarn test             # run unit tests once
 yarn build            # confirm a production build compiles
 ```
 
-A Husky pre-commit hook runs `pretty-quick` on staged files, but the full set
-above still catches more. Open your PR against **`staging`** or **`main`** (the
+A Husky pre-commit hook runs `yarn lint` and `yarn prettier:check`, but the full
+set above still catches more. Open your PR against **`staging`** or **`main`** (the
 branches CI runs PR checks on); add the `On Staging` / `On Development` label to
 deploy it to a test environment.
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ project from a clean machine. By the end you'll have the app running locally at
 
 ### Prerequisites
 
-| Tool       | Version    | Why                                        |
-| ---------- | ---------- | ------------------------------------------ |
-| Node.js    | `20.17.0`  | Defined in [`.tool-versions`](.tool-versions) |
-| Yarn       | `4.7.0`    | Package manager (bundled via `.yarn/releases`) |
-| Git        | any recent | Cloning the repo and deploying             |
-| Homebrew   | any recent | Installing asdf                            |
+| Tool     | Version    | Why                                            |
+| -------- | ---------- | ---------------------------------------------- |
+| Node.js  | `24.9.0`   | Defined in [`.tool-versions`](.tool-versions)  |
+| Yarn     | `4.7.0`    | Package manager (bundled via `.yarn/releases`) |
+| Git      | any recent | Cloning the repo and deploying                 |
+| Homebrew | any recent | Installing asdf                                |
 
 This project pins exact tool versions, so matching them avoids hard-to-debug
 issues. Node is managed with [asdf](https://asdf-vm.com/) and Yarn is committed
@@ -36,7 +36,7 @@ cd know-god-web
 
 ### Step 2 — Install the correct Node version with asdf
 
-This project requires Node `20.17.0`. Check what you have with `node --version`.
+This project requires Node `24.9.0`. Check what you have with `node --version`.
 If it doesn't match, install the pinned version with asdf.
 
 ```bash
@@ -58,11 +58,11 @@ echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
 asdf install nodejs
 
 # Confirm you're now on the right version
-node --version   # should print v20.17.0
+node --version   # should print v24.9.0
 ```
 
 Because the version is pinned in `.tool-versions`, asdf automatically switches to
-`20.17.0` whenever you `cd` into this project.
+`24.9.0` whenever you `cd` into this project.
 
 ### Step 3 — Verify Yarn
 
@@ -110,20 +110,20 @@ the site. The server hot-reloads as you edit files.
 
 ### Useful scripts
 
-| Command               | What it does                                            |
-| --------------------- | ------------------------------------------------------- |
-| `yarn start`          | Dev server, production configuration                    |
-| `yarn start:dev`      | Dev server, development configuration (staging data)    |
-| `yarn build`          | Production build                                         |
-| `yarn build:dev`      | Development build                                        |
-| `yarn test`           | Run unit tests once (Karma + Jasmine)                   |
-| `yarn lint`           | Lint and auto-fix `src/**/*.{js,ts,html}`               |
-| `yarn prettier:check` | Report files that aren't formatted                      |
-| `yarn prettier:write` | Format all files                                        |
+| Command               | What it does                                         |
+| --------------------- | ---------------------------------------------------- |
+| `yarn start`          | Dev server, production configuration                 |
+| `yarn start:dev`      | Dev server, development configuration (staging data) |
+| `yarn build`          | Production build                                     |
+| `yarn build:dev`      | Development build                                    |
+| `yarn test`           | Run unit tests once (Karma + Jasmine)                |
+| `yarn lint`           | Lint and auto-fix `src/**/*.{js,ts,html}`            |
+| `yarn prettier:check` | Report files that aren't formatted                   |
+| `yarn prettier:write` | Format all files                                     |
 
 ### Troubleshooting
 
-- **`node --version` doesn't show `20.17.0`** — Make sure you opened a new
+- **`node --version` doesn't show `24.9.0`** — Make sure you opened a new
   terminal after the asdf shell integration step, and that you're inside the
   repo directory so asdf reads `.tool-versions`.
 - **`command not found: yarn`** — Run `corepack enable`, then retry. Yarn is
@@ -231,7 +231,7 @@ describe('DashboardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [DashboardComponent],
+      declarations: [DashboardComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(DashboardComponent);
@@ -249,15 +249,42 @@ then assert against the rendered DOM or the component instance.
 
 ## Embed
 
-Any site can drop a Know God tool onto a page with two lines of HTML:
+Add the following snippet to any HTML page to embed a KnowGod.com gospel presentation:
 
 ```html
-<div id="knowGodEmbed" data-book="kgp-us" data-lang="en"></div>
+<div
+  id="knowGodEmbed"
+  data-book="kgp-us"
+  data-lang="en"
+  data-ministry="your-ministry-name"
+></div>
 <script src="https://knowgod.com/embed.js"></script>
 ```
 
-- `data-book` — the resource/tool to load (e.g. `kgp-us` for "Knowing God Personally").
-- `data-lang` — the language code (e.g. `en`).
+### Data Attributes
+
+| Attribute       | Required | Description                                                                                   |
+| --------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `data-book`     | Yes      | The book/resource identifier (e.g. `kgp-us`, `satisfied`)                                     |
+| `data-lang`     | Yes      | Language code (e.g. `en`, `es`, `fr`)                                                         |
+| `data-ministry` | No       | Your ministry identifier. Used for analytics to track which ministries are embedding content. |
+
+The script creates an iframe pointing to `https://knowgod.com/#/{lang}/{book}?embedded=true`. When `data-ministry` is provided, a `&ministry={value}` parameter is appended to the URL so the analytics service can attribute embeds to specific ministries.
+
+### Testing the Embed Locally
+
+A test page is available at `embed/test.html` to verify the embed script works correctly. Start the dev server and open the test page:
+
+```bash
+yarn start
+# then open http://localhost:4200/embed/test.html
+```
+
+The test page uses `window.location.origin` to dynamically point the iframe at the current host, so it works in any environment without needing the `{appDomain}` placeholder that CI/CD replaces in the production `embed.js`.
+
+You can change the `data-book`, `data-lang`, and `data-ministry` values and click **Reload Embed** to test different configurations. The log panel at the bottom shows the generated iframe URL and any `postMessage` height updates received from the embedded content.
+
+## Environments
 
 A working example lives in [`embed/example.html`](embed/example.html).
 
@@ -291,7 +318,7 @@ full flow:
 5. **Auto-resizing (iframe → parent).** Because the app lives in an iframe, the
    host page can't know how tall the content is. The app handles this from inside
    the iframe (`src/index.html`): it detects it's embedded (`window.location !==
-   window.parent.location`), then uses a `MutationObserver` to watch for content
+window.parent.location`), then uses a `MutationObserver` to watch for content
    changes and calls `parent.postMessage(document.body.offsetHeight, '*')`
    whenever the height changes (with a few delayed re-sends to account for images
    loading).
@@ -352,23 +379,23 @@ yarn add crowdin @crowdin/cli
 ### Crowdin project
 
 - **Project ID:** `897600` _(temporary — to be migrated to a new project owned by
-  Sway Ciaramello)._
+  Daniel Frett)._
 - **`CROWDIN_API_TOKEN`** is created in the Crowdin project and stored as a GitHub
   Actions repository secret at
   [Settings → Secrets → Actions](https://github.com/CruGlobal/know-god-web/settings/secrets/actions).
 
 ### Files and what they do
 
-| File | Purpose |
-| --- | --- |
-| `src/app/i18n.ts` | Starts up i18next when the app loads |
-| `src/app/app.module.ts` | Registers i18next with Angular so the `i18next` pipe works in templates |
-| `i18next-parser.config.cjs` | Config for `yarn extract`; a custom lexer matches the `'key' \| i18next` pattern in HTML and extracts the key |
-| `crowdin/sort-translations.cjs` | Alphabetically sorts every locale's `translation.json` |
-| `src/assets/locales/en/translation.json` | The generated English source file |
-| `crowdin.yml` | Crowdin project config — which file is the source, where translations go, and who reviews the auto-PRs |
-| `.github/workflows/node.js.yml` | Adds a translation job to CI so every PR runs `yarn extract` |
-| `.github/workflows/crowdin.yml` | Scheduled job that extracts, downloads translations from Crowdin, sorts them, and opens the "Update translations" PR |
+| File                                     | Purpose                                                                                                              |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `src/app/i18n.ts`                        | Starts up i18next when the app loads                                                                                 |
+| `src/app/app.module.ts`                  | Registers i18next with Angular so the `i18next` pipe works in templates                                              |
+| `i18next-parser.config.cjs`              | Config for `yarn extract`; a custom lexer matches the `'key' \| i18next` pattern in HTML and extracts the key        |
+| `crowdin/sort-translations.cjs`          | Alphabetically sorts every locale's `translation.json`                                                               |
+| `src/assets/locales/en/translation.json` | The generated English source file                                                                                    |
+| `crowdin.yml`                            | Crowdin project config — which file is the source, where translations go, and who reviews the auto-PRs               |
+| `.github/workflows/node.js.yml`          | Adds a translation job to CI so every PR runs `yarn extract`                                                         |
+| `.github/workflows/crowdin.yml`          | Scheduled job that extracts, downloads translations from Crowdin, sorts them, and opens the "Update translations" PR |
 
 ### Using it in templates
 
@@ -381,7 +408,8 @@ The key **is the full English string**. Simple string:
 String with a dynamic value:
 
 ```html
-{{ '1994-{{ year }} Cru. All Rights Reserved.' | i18next: { year: currentYear } }}
+{{ '1994-{{ year }} Cru. All Rights Reserved.' | i18next: { year: currentYear }
+}}
 ```
 
 These produce the following entries in `translation.json` (keys are the full
@@ -408,12 +436,12 @@ Runs on pushes to `staging`, `development`, and `main`, and on pull requests
 targeting `staging` or `main`. Every job installs dependencies first (Node
 version comes from `.tool-versions`). The four jobs are:
 
-| Job                      | What it checks                                                                 |
-| ------------------------ | ------------------------------------------------------------------------------ |
-| 🧹 **Lint & Prettier**   | Runs `yarn prettier:check` then `yarn lint` — fails if anything is unformatted or violates lint rules. |
-| ✅ **Tests**             | Runs `yarn test --no-watch` (Karma + Jasmine unit tests, single run).          |
-| 🏗️ **Build app**         | Runs `yarn build` to confirm a production build compiles.                      |
-| 🚀 **Deploy app**        | Only on pushes (not PRs) to `main`/`staging`/`development`. Waits for the three jobs above to pass, builds with the env-matched configuration, injects the host into `embed.js`, copies the `mobile/` directory, and syncs everything to S3. |
+| Job                    | What it checks                                                                                                                                                                                                                               |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🧹 **Lint & Prettier** | Runs `yarn prettier:check` then `yarn lint` — fails if anything is unformatted or violates lint rules.                                                                                                                                       |
+| ✅ **Tests**           | Runs `yarn test --no-watch` (Karma + Jasmine unit tests, single run).                                                                                                                                                                        |
+| 🏗️ **Build app**       | Runs `yarn build` to confirm a production build compiles.                                                                                                                                                                                    |
+| 🚀 **Deploy app**      | Only on pushes (not PRs) to `main`/`staging`/`development`. Waits for the three jobs above to pass, builds with the env-matched configuration, injects the host into `embed.js`, copies the `mobile/` directory, and syncs everything to S3. |
 
 The deploy job picks its target environment from the branch: `main` → prod,
 `staging` → stage, `development` → dev. PRs never deploy — they only run lint,
@@ -471,14 +499,18 @@ To update who the owners are, edit `.github/CODEOWNERS`.
 
 ## Environments at a glance
 
-| Environment | URL                            | Deploys from |
-| ----------- | ------------------------------ | ------------ |
-| Production  | https://knowgod.com/en         | `main`       |
-| Staging     | https://stage.knowgod.com/en   | `staging`    |
-| Development | https://dev.knowgod.com/en     | —            |
-| Local       | http://localhost:4200/en       | —            |
+| Environment | URL                          | Deploys from |
+| ----------- | ---------------------------- | ------------ |
+| Production  | https://knowgod.com/en       | `main`       |
+| Staging     | https://stage.knowgod.com/en | `staging`    |
+| Development | https://dev.knowgod.com/en   | —            |
+| Local       | http://localhost:4200/en     | —            |
 
 ### Deploy
 
 - Push to `staging` to auto-deploy to stage.knowgod.com
 - Push to `main` to auto-deploy to knowgod.com
+
+## Documentation
+
+Additional documentation can be found in the `docs/` directory.

--- a/README.md
+++ b/README.md
@@ -248,9 +248,14 @@ Embed**; the log panel shows the generated URL and incoming height updates.
 Developers only write **English** strings in templates with the `i18next` pipe;
 extraction, upload, and the translation-return PR are automated:
 
-1. Write a string: `{{ 'Tools' | i18next }}` (or with a value:
-   `{{ '1994-{{ year }} Cru.' | i18next: { year: currentYear } }}`). The key
-   **is** the full English string.
+1. Write a string: `{{ 'Tools' | i18nextEager }}` (or with a value:
+   `{{ '1994-{{ year }} Cru.' | i18nextEager: { year: currentYear } }}`). The
+   key **is** the full English string.
+
+   > **Use `i18nextEager`, not the bare `i18next` pipe.** `i18next` resolves
+   > once and caches, so labels go stale when the in-app language selector
+   > switches language without re-rendering. `i18nextEager` re-resolves on
+   > language change, keeping persistent labels in sync.
 2. `yarn extract` writes keys into `src/assets/locales/en/translation.json`;
    commit it with your change.
 3. On merge to `main`, English strings upload to Crowdin.


### PR DESCRIPTION
## Description

This work is for OKR1 outlined [here](https://docs.google.com/spreadsheets/d/1dIhUq7UPPEl-DzJYD6G6cY9-Ey2r8EGSikaHREerUoc/edit?gid=617028509#gid=617028509&range=C50). The primary goal of this PR is to set up the documentation, guidelines, and procedures for external contributors to `know-god-web`.

- Expand `README.md` with setup, embed, CI, and PR guidance
- Add `CONTRIBUTING.md` for newcomers/contractors
- Add `.github/PULL_REQUEST_TEMPLATE.md` adapted to `know-god-web`
- Add `.github/CODEOWNERS`
- Enable CruGlobal claude-code-plugins via `.claude/settings.json` + `CLAUDE.md`

**Related:** branch protections were added in this [cru-terraform PR](https://github.com/CruGlobal/cru-terraform/pull/10695).

_No Jira ticket — tracked via OKR1._

This is a documentation- and config-only change; there are no application code or UI changes, so no screenshots/recordings apply.

## Testing

This PR touches docs and Claude Code config only — no runtime behavior changes. To verify:

- Read through `README.md` and `CONTRIBUTING.md` and confirm the setup, embed, CI, and PR-workflow instructions render correctly and are accurate.
- Confirm `.github/PULL_REQUEST_TEMPLATE.md` is what populates the body of this PR.
- Confirm `.github/CODEOWNERS` lists the intended owners.
- Optionally, confirm the app still builds/runs and nothing was broken:
  - `yarn install`
  - `yarn start:dev` and load <http://localhost:4200/en>
  - `yarn lint`, `yarn prettier:check`, `yarn test --no-watch`, `yarn build`

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [ ] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [ ] `yarn test --no-watch` passes locally
- [ ] I have run `/agent-review` and addressed its findings before requesting a dev review
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes on staging or development
- [ ] I have cleaned up my commit history
