### PR TITLE
[No-Jira] Add skip flag for translations

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,6 +6,7 @@
 'pull_request_reviewers':
   ['dr-bizz', 'canac', 'kegrimes', 'wjames111', 'zweatshirt']
 'preserve_hierarchy': true
+'skip_untranslated_strings': true
 files:
   [
     {

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,7 +6,6 @@
 'pull_request_reviewers':
   ['dr-bizz', 'canac', 'kegrimes', 'wjames111', 'zweatshirt']
 'preserve_hierarchy': true
-'skip_untranslated_strings': true
 files:
   [
     {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "postinstall": "husky install",
     "extract": "i18next --config i18next-parser.config.cjs",
     "crowdin:sort-translations": "node ./crowdin/sort-translations.cjs",
-    "crowdin:download": "crowdin download translations && yarn crowdin:sort-translations",
+    "crowdin:download": "crowdin download translations --skip-untranslated-strings && yarn crowdin:sort-translations",
     "crowdin:upload": "crowdin upload translations"
   },
   "type": "module",


### PR DESCRIPTION
Currently, all translation files were filling in missing translations with the english source. Instead, we want to skip any untranslated strings. Add the `skip-untranslated-strings` flag to the download command and remove `en` from Crowdin target languages. 

Verified with running `crowdin download translations --skip-untranslated-strings` ✅