### PR TITLE
GT-2855 Adjust flow item behvaior

### DIFF
--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -10,6 +10,7 @@ import {
   EventId,
   Flow,
   FlowItem,
+  FlowWatcher,
   Image,
   Input,
   LessonPage,
@@ -746,5 +747,33 @@ export const mockSpacer = (height = 100): Spacer => {
       ordinal: 0
     },
     ...standardTypeValues()
+  };
+};
+
+export const mockVisibilityWatchers = (item: Content) => {
+  const goneClose = jasmine.createSpy('goneClose');
+  const invisibleClose = jasmine.createSpy('invisibleClose');
+  let goneCallback: (value: boolean) => void = () => {};
+  let invisibleCallback: (value: boolean) => void = () => {};
+
+  spyOn(item, 'watchIsGone').and.callFake(
+    (_state: ParserState, callback: (value: boolean) => void) => {
+      goneCallback = callback;
+      return { close: goneClose } as unknown as FlowWatcher;
+    }
+  );
+  spyOn(item, 'watchIsInvisible').and.callFake(
+    (_state: ParserState, callback: (value: boolean) => void) => {
+      invisibleCallback = callback;
+      return { close: invisibleClose } as unknown as FlowWatcher;
+    }
+  );
+
+  return {
+    item,
+    goneClose,
+    invisibleClose,
+    triggerGone: (value: boolean) => goneCallback(value),
+    triggerInvisible: (value: boolean) => invisibleCallback(value)
   };
 };

--- a/src/app/page/component/content-flow-item/content-flow-item.component.html
+++ b/src/app/page/component/content-flow-item/content-flow-item.component.html
@@ -1,7 +1,3 @@
-<div
-  *ngIf="ready && !visibility.isHidden"
-  [style.visibility]="visibility.isInvisible ? 'hidden' : 'visible'"
-  class="flow-item"
->
+<div *ngIf="ready" class="flow-item">
   <app-content-repeater [items]="contents"></app-content-repeater>
 </div>

--- a/src/app/page/component/content-flow-item/content-flow-item.component.ts
+++ b/src/app/page/component/content-flow-item/content-flow-item.component.ts
@@ -2,7 +2,6 @@ import {
   Component,
   Input,
   OnChanges,
-  OnDestroy,
   SimpleChanges,
   ViewEncapsulation
 } from '@angular/core';
@@ -10,8 +9,6 @@ import {
   Content,
   FlowItem
 } from 'src/app/services/xml-parser-service/xml-parser.service';
-import { PageService } from '../../service/page-service.service';
-import { VisibilityWatchers } from '../visibility-watchers/visibility-watchers';
 
 @Component({
   selector: 'app-content-flow-item',
@@ -19,15 +16,10 @@ import { VisibilityWatchers } from '../visibility-watchers/visibility-watchers';
   styleUrls: ['./content-flow-item.component.css'],
   encapsulation: ViewEncapsulation.None
 })
-export class ContentFlowItemComponent implements OnChanges, OnDestroy {
+export class ContentFlowItemComponent implements OnChanges {
   @Input() item: FlowItem;
   contents: Content[];
   ready: boolean;
-  visibility: VisibilityWatchers;
-
-  constructor(private pageService: PageService) {
-    this.visibility = new VisibilityWatchers(this.pageService);
-  }
 
   ngOnChanges(changes: SimpleChanges) {
     for (const propName in changes) {
@@ -47,13 +39,7 @@ export class ContentFlowItemComponent implements OnChanges, OnDestroy {
     }
   }
 
-  ngOnDestroy(): void {
-    this.visibility.closeWatchers();
-  }
-
   private init(): void {
-    this.visibility.init(this.item);
-
     const contents: Content[] = [];
     this.item.content.forEach((content) =>
       content ? contents.push(content) : null

--- a/src/app/page/component/content-flow/content-flow.component.html
+++ b/src/app/page/component/content-flow/content-flow.component.html
@@ -7,10 +7,12 @@
   >
     <!-- Subtract 17.5px from the percentage to account for the gap between flow-items  -->
     <app-content-flow-item
-      *ngFor="let item of items; trackBy: trackByFn"
-      [item]="item"
+      *ngFor="let contentItem of items; trackBy: trackByFn"
+      [item]="contentItem.item"
+      [hidden]="contentItem.visibility?.isHidden"
       [ngStyle]="{
-        flexBasis: 'calc(' + item.itemWidth + ' - 17.5px)'
+        flexBasis: 'calc(' + contentItem.itemWidth + ' - 17.5px)',
+        visibility: contentItem.visibility?.isInvisible ? 'hidden' : 'visible'
       }"
     >
     </app-content-flow-item>

--- a/src/app/page/component/content-flow/content-flow.component.spec.ts
+++ b/src/app/page/component/content-flow/content-flow.component.spec.ts
@@ -1,12 +1,18 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { mockFlow } from '../../../_tests/mocks';
+import {
+  Flow,
+  FlowItem
+} from 'src/app/services/xml-parser-service/xml-parser.service';
+import { mockFlow, mockVisibilityWatchers } from '../../../_tests/mocks';
 import { ContentFlowComponent } from './content-flow.component';
+
+const wireFlowItems = (flow: Flow) =>
+  flow.items.map((item: FlowItem) => mockVisibilityWatchers(item));
 
 describe('ContentFlowComponent', () => {
   let component: ContentFlowComponent;
   let fixture: ComponentFixture<ContentFlowComponent>;
-  const flow = mockFlow();
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -17,12 +23,67 @@ describe('ContentFlowComponent', () => {
     fixture.detectChanges();
   }));
 
-  it('Values are assigned correctly', async () => {
+  const initWith = (flow: Flow) => {
     component.item = flow;
-    component.ngOnChanges({
-      item: new SimpleChange(null, flow, true)
-    });
-    expect(component.items).toEqual(flow.items);
+    component.ngOnChanges({ item: new SimpleChange(null, flow, true) });
+  };
+
+  it('Values are assigned correctly', () => {
+    const flow = mockFlow();
+    initWith(flow);
+
+    expect(component.items.map((content) => content.item)).toEqual(flow.items);
     expect(component.ready).toBeTrue();
+  });
+
+  it('creates a visibility watcher for every flow item', () => {
+    const flow = mockFlow();
+    initWith(flow);
+
+    expect(component.items.length).toBe(flow.items.length);
+    component.items.forEach((content) =>
+      expect(content.visibility).toBeDefined()
+    );
+  });
+
+  it('reflects each item gone/invisible state from its watcher', () => {
+    const flow = mockFlow();
+    const wired = wireFlowItems(flow);
+    initWith(flow);
+
+    wired[0].triggerGone(true);
+    expect(component.items[0].visibility?.isHidden).toBeTrue();
+
+    wired[1].triggerInvisible(true);
+    expect(component.items[1].visibility?.isInvisible).toBeTrue();
+  });
+
+  it('closes every item watcher on destroy', () => {
+    const flow = mockFlow();
+    const wired = wireFlowItems(flow);
+    initWith(flow);
+
+    component.ngOnDestroy();
+
+    wired.forEach((w) => {
+      expect(w.goneClose).toHaveBeenCalledTimes(1);
+      expect(w.invisibleClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('closes the previous flow watchers before re-initializing', () => {
+    const firstFlow = mockFlow();
+    const wiredFirst = wireFlowItems(firstFlow);
+    initWith(firstFlow);
+
+    const secondFlow = mockFlow();
+    component.ngOnChanges({
+      item: new SimpleChange(firstFlow, secondFlow, false)
+    });
+
+    wiredFirst.forEach((w) => {
+      expect(w.goneClose).toHaveBeenCalledTimes(1);
+      expect(w.invisibleClose).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/app/page/component/content-flow/content-flow.component.ts
+++ b/src/app/page/component/content-flow/content-flow.component.ts
@@ -1,29 +1,42 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges
+} from '@angular/core';
 import {
   DimensionParser,
   Flow,
   FlowItem,
-  Horizontal,
-  ParserState
+  Horizontal
 } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { PageService } from '../../service/page-service.service';
+import { VisibilityWatchers } from '../visibility-watchers/visibility-watchers';
+
+type FlowContent = {
+  item: FlowItem;
+  itemWidth?: string | null;
+  visibility?: VisibilityWatchers;
+};
 
 @Component({
   selector: 'app-content-flow',
   templateUrl: './content-flow.component.html',
   styleUrls: ['./content-flow.component.css']
 })
-export class ContentFlowComponent implements OnChanges {
+export class ContentFlowComponent implements OnChanges, OnDestroy {
   @Input() item: Flow;
 
   flow: Flow;
-  items: (FlowItem & { itemWidth?: string | null })[];
+  items: FlowContent[];
   ready: boolean;
-  state: ParserState;
   justifyContent: Horizontal;
 
-  constructor(private pageService: PageService) {
-    this.state = this.pageService.parserState();
+  constructor(private pageService: PageService) {}
+
+  ngOnDestroy(): void {
+    this.closeItemWatchers();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -49,15 +62,31 @@ export class ContentFlowComponent implements OnChanges {
     return index;
   }
 
+  private closeItemWatchers(): void {
+    this.items?.forEach((contentItem) =>
+      contentItem.visibility?.closeWatchers()
+    );
+  }
+
   private init(): void {
-    this.items = this.item.items;
-    this.items.forEach((flowItem) => {
+    this.closeItemWatchers();
+
+    this.items = this.flow.items.map((flowItem) => {
       const dimension = DimensionParser(flowItem.width);
-      flowItem.itemWidth = dimension?.value
+      const itemWidth = dimension?.value
         ? dimension.value + dimension.symbol
         : null;
+
+      const visibility = new VisibilityWatchers(this.pageService);
+      visibility.init(flowItem);
+
+      return {
+        item: flowItem,
+        itemWidth,
+        visibility
+      };
     });
-    this.justifyContent = this.item.rowGravity;
+    this.justifyContent = this.flow.rowGravity;
     this.ready = true;
   }
 }

--- a/src/app/page/component/visibility-watchers/visibility-watchers.spec.ts
+++ b/src/app/page/component/visibility-watchers/visibility-watchers.spec.ts
@@ -1,39 +1,7 @@
-import {
-  Content,
-  FlowWatcher,
-  ParserState
-} from 'src/app/services/xml-parser-service/xml-parser.service';
-import { mockText } from '../../../_tests/mocks';
+import { ParserState } from 'src/app/services/xml-parser-service/xml-parser.service';
+import { mockText, mockVisibilityWatchers } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
 import { VisibilityWatchers } from './visibility-watchers';
-
-const wireWatchers = (item: Content) => {
-  const goneClose = jasmine.createSpy('goneClose');
-  const invisibleClose = jasmine.createSpy('invisibleClose');
-  let goneCallback: (value: boolean) => void = () => {};
-  let invisibleCallback: (value: boolean) => void = () => {};
-
-  spyOn(item, 'watchIsGone').and.callFake(
-    (_state: ParserState, callback: (value: boolean) => void) => {
-      goneCallback = callback;
-      return { close: goneClose } as unknown as FlowWatcher;
-    }
-  );
-  spyOn(item, 'watchIsInvisible').and.callFake(
-    (_state: ParserState, callback: (value: boolean) => void) => {
-      invisibleCallback = callback;
-      return { close: invisibleClose } as unknown as FlowWatcher;
-    }
-  );
-
-  return {
-    item,
-    goneClose,
-    invisibleClose,
-    triggerGone: (value: boolean) => goneCallback(value),
-    triggerInvisible: (value: boolean) => invisibleCallback(value)
-  };
-};
 
 describe('VisibilityWatchers', () => {
   let pageService: PageService;
@@ -53,7 +21,7 @@ describe('VisibilityWatchers', () => {
 
   describe('init', () => {
     it('opens a gone and an invisible watcher, passing the parser state', () => {
-      const { item } = wireWatchers(mockText('sample'));
+      const { item } = mockVisibilityWatchers(mockText('sample'));
 
       visibility.init(item);
 
@@ -68,7 +36,7 @@ describe('VisibilityWatchers', () => {
     });
 
     it('updates isHidden when the gone watcher emits', () => {
-      const watchers = wireWatchers(mockText('sample'));
+      const watchers = mockVisibilityWatchers(mockText('sample'));
       visibility.init(watchers.item);
 
       watchers.triggerGone(true);
@@ -79,7 +47,7 @@ describe('VisibilityWatchers', () => {
     });
 
     it('updates isInvisible when the invisible watcher emits', () => {
-      const watchers = wireWatchers(mockText('sample'));
+      const watchers = mockVisibilityWatchers(mockText('sample'));
       visibility.init(watchers.item);
 
       watchers.triggerInvisible(true);
@@ -90,10 +58,10 @@ describe('VisibilityWatchers', () => {
     });
 
     it('closes the previous watchers before opening new ones on re-init', () => {
-      const first = wireWatchers(mockText('first'));
+      const first = mockVisibilityWatchers(mockText('first'));
       visibility.init(first.item);
 
-      const second = wireWatchers(mockText('second'));
+      const second = mockVisibilityWatchers(mockText('second'));
       visibility.init(second.item);
 
       expect(first.goneClose).toHaveBeenCalledTimes(1);
@@ -103,7 +71,7 @@ describe('VisibilityWatchers', () => {
 
   describe('closeWatchers', () => {
     it('closes both watchers', () => {
-      const watchers = wireWatchers(mockText('sample'));
+      const watchers = mockVisibilityWatchers(mockText('sample'));
       visibility.init(watchers.item);
 
       visibility.closeWatchers();


### PR DESCRIPTION
## Description

Currently for flow items, `gone-if` is being removed correctly, but still retaining position. To fix this, I have moved the visibility logic up a level to the parent (`content-flow-item` to `content-flow`) so it can own each watcher per item. 

Jira ticket: [GT-2855](https://jira.cru.org/browse/GT-2855)

**Before:**
<img width="840" height="712" alt="Screenshot 2026-06-10 at 4 54 48 PM" src="https://github.com/user-attachments/assets/e6cee0a9-0fa6-44a7-bdb6-a82f3e7b2f47" />

**After:**
<img width="819" height="423" alt="Screenshot 2026-06-10 at 4 54 13 PM" src="https://github.com/user-attachments/assets/9580b182-3439-4cc9-a002-37a4ab91c391" />


## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Tips:
- Run the app locally with `yarn start:dev` (or check the deployed staging build once the "On Staging" label is applied).
- If the change affects the embed, test it via `embed/example.html` and confirm the tool still loads inside the iframe.
- Note the relevant tool/language (e.g. `data-book=kgp-us`, `data-lang=en`) the reviewer should use.

Example:
- Go to /#/en/kgp-us
- Navigate to the next page of the tool
- Check that the page renders correctly
-->

- Go to `/en/tool/v1/emojitool/1`
- Select 3 random emojis and go to next page
- Check that items and position are removed

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [x] I have run `/agent-review` and addressed its findings before requesting a dev review
- [x] I have requested a review from another person on the project
- [x] I have tested my changes on staging or development
- [x] I have cleaned up my commit history
