### PR TITLE
[No Jira] - remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-# Code owners for know-god-web
-#
-# GitHub automatically requests a review from the owners listed here whenever a
-# pull request changes a matching path. The pattern below covers the whole repo,
-# so every PR requests a review from these people.
-#
-# Docs: https://docs.github.com/articles/about-code-owners
-
-* @kegrimes @wjames111 @dr-bizz @canac @zweatshirt


### PR DESCRIPTION
## Description

All reviewers in CODEOWNERS file were getting pinged for an open PR. Remove CODEOWNERS file. A separate [PR](https://github.com/CruGlobal/cru-terraform/pull/10823) has been created to ensure 1 passing review from web_engineering_js team.

## Testing

N/A fix won't take affect until PRs merge

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [x] I have run `/agent-review` and addressed its findings before requesting a dev review
- [x] I have requested a review from another person on the project
- [ ] I have tested my changes on staging or development
- [ ] I have cleaned up my commit history
