### PR TITLE
[No Jira] - Add Review label workflow to auto-request team review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,6 @@ Example:
 - [ ] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
 - [ ] `yarn test --no-watch` passes locally
 - [ ] I have run `/agent-review` and addressed its findings before requesting a dev review
-- [ ] I have requested a review from another person on the project
+- [ ] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from the team
 - [ ] I have tested my changes on staging or development
 - [ ] I have cleaned up my commit history

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,6 @@ Example:
 - [ ] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
 - [ ] `yarn test --no-watch` passes locally
 - [ ] I have run `/agent-review` and addressed its findings before requesting a dev review
-- [ ] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from the team
+- [ ] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from a randomly-chosen team member
 - [ ] I have tested my changes on staging or development
 - [ ] I have cleaned up my commit history

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -1,12 +1,5 @@
 name: Request Team Review
 
-# When the "Review" label is applied to a PR, request a review from one
-# randomly-chosen member of the web-engineering-js team (excluding the PR
-# author). This replaces the old CODEOWNERS auto-requests, which pinged every
-# owner on every PR.
-#
-# Uses pull_request_target so the token has write permissions on PRs from
-# forks. This is safe because the workflow never checks out PR code.
 on:
   pull_request_target:
     types: [labeled]
@@ -47,11 +40,17 @@ jobs:
               console.log(`Could not list team members (${error.message}); using fallback list.`);
             }
 
-            // Don't request a review from the PR author or anyone already requested.
+            // Bail out if a team member already has a pending review request
+            // (e.g. the label was re-applied or someone was requested manually).
             const alreadyRequested = (pr.requested_reviewers || []).map((r) => r.login);
-            const candidates = members.filter(
-              (login) => login !== pr.user.login && !alreadyRequested.includes(login)
-            );
+            const pendingMember = alreadyRequested.find((login) => members.includes(login));
+            if (pendingMember) {
+              console.log(`${pendingMember} already has a pending review request; nothing to do.`);
+              return;
+            }
+
+            // Don't request a review from the PR author.
+            const candidates = members.filter((login) => login !== pr.user.login);
 
             if (candidates.length === 0) {
               console.log('No eligible reviewers to request.');

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -1,0 +1,44 @@
+name: Request Team Review
+
+# When the "Review" label is applied to a PR, request a review from the
+# web-engineering-js team. This replaces the old CODEOWNERS auto-requests:
+# reviews are only requested once the author marks the PR ready by labeling it.
+#
+# Uses pull_request_target so the token has write permissions on PRs from
+# forks. This is safe because the workflow never checks out PR code.
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    name: 👀 Request review from team
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Review' && github.event.pull_request.draft == false
+    steps:
+      - name: Request review from web-engineering-js
+        uses: actions/github-script@v7
+        with:
+          # Requesting a *team* review requires a token with org read access,
+          # which the default GITHUB_TOKEN may not have. If this step fails,
+          # add a REVIEW_BOT_TOKEN secret (PAT with repo + read:org scopes).
+          github-token: ${{ secrets.REVIEW_BOT_TOKEN || github.token }}
+          script: |
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                team_reviewers: ['web-engineering-js'],
+              });
+              console.log('Requested review from web-engineering-js');
+            } catch (error) {
+              core.setFailed(
+                `Could not request team review: ${error.message}. ` +
+                'If this is a permissions error, add a REVIEW_BOT_TOKEN secret ' +
+                '(PAT with repo + read:org scopes).'
+              );
+            }

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -1,8 +1,9 @@
 name: Request Team Review
 
-# When the "Review" label is applied to a PR, request a review from the
-# web-engineering-js team. This replaces the old CODEOWNERS auto-requests:
-# reviews are only requested once the author marks the PR ready by labeling it.
+# When the "Review" label is applied to a PR, request a review from one
+# randomly-chosen member of the web-engineering-js team (excluding the PR
+# author). This replaces the old CODEOWNERS auto-requests, which pinged every
+# owner on every PR.
 #
 # Uses pull_request_target so the token has write permissions on PRs from
 # forks. This is safe because the workflow never checks out PR code.
@@ -15,30 +16,58 @@ permissions:
 
 jobs:
   request-review:
-    name: 👀 Request review from team
+    name: 👀 Request review from a team member
     runs-on: ubuntu-latest
     if: github.event.label.name == 'Review' && github.event.pull_request.draft == false
     steps:
-      - name: Request review from web-engineering-js
+      - name: Request review from a random web-engineering-js member
         uses: actions/github-script@v7
         with:
-          # Requesting a *team* review requires a token with org read access,
-          # which the default GITHUB_TOKEN may not have. If this step fails,
-          # add a REVIEW_BOT_TOKEN secret (PAT with repo + read:org scopes).
+          # Listing team members requires org read access, which the default
+          # GITHUB_TOKEN does not have. Without a REVIEW_BOT_TOKEN secret
+          # (PAT with repo + read:org scopes), the fallback list below is used.
           github-token: ${{ secrets.REVIEW_BOT_TOKEN || github.token }}
           script: |
+            const pr = context.payload.pull_request;
+
+            // Fallback list, kept in sync with the web-engineering-js team
+            // (see cru-terraform/github/CruGlobal/teams/web_engineering_js).
+            let members = ['canac', 'dr-bizz', 'kegrimes', 'zweatshirt', 'wjames111'];
+
+            // Prefer the live team membership so this list never goes stale.
+            try {
+              const response = await github.paginate(github.rest.teams.listMembersInOrg, {
+                org: context.repo.owner,
+                team_slug: 'web-engineering-js',
+              });
+              if (response.length > 0) {
+                members = response.map((member) => member.login);
+              }
+            } catch (error) {
+              console.log(`Could not list team members (${error.message}); using fallback list.`);
+            }
+
+            // Don't request a review from the PR author or anyone already requested.
+            const alreadyRequested = (pr.requested_reviewers || []).map((r) => r.login);
+            const candidates = members.filter(
+              (login) => login !== pr.user.login && !alreadyRequested.includes(login)
+            );
+
+            if (candidates.length === 0) {
+              console.log('No eligible reviewers to request.');
+              return;
+            }
+
+            const reviewer = candidates[Math.floor(Math.random() * candidates.length)];
+
             try {
               await github.rest.pulls.requestReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-                team_reviewers: ['web-engineering-js'],
+                pull_number: pr.number,
+                reviewers: [reviewer],
               });
-              console.log('Requested review from web-engineering-js');
+              console.log(`Requested review from ${reviewer}`);
             } catch (error) {
-              core.setFailed(
-                `Could not request team review: ${error.message}. ` +
-                'If this is a permissions error, add a REVIEW_BOT_TOKEN secret ' +
-                '(PAT with repo + read:org scopes).'
-              );
+              core.setFailed(`Could not request review from ${reviewer}: ${error.message}`);
             }

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -1,7 +1,11 @@
 name: Request Team Review
 
+# Uses the plain pull_request trigger (not pull_request_target) to avoid
+# running with elevated permissions on attacker-controlled events. Limitation:
+# the token is read-only on PRs from forks, so those are skipped — request a
+# review manually on fork PRs.
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
 
 permissions:
@@ -22,6 +26,12 @@ jobs:
           github-token: ${{ secrets.REVIEW_BOT_TOKEN || github.token }}
           script: |
             const pr = context.payload.pull_request;
+
+            // Fork PRs get a read-only token, so we can't request reviewers.
+            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.notice('PR is from a fork; skipping auto-request. Please request a review manually.');
+              return;
+            }
 
             // Fallback list, kept in sync with the web-engineering-js team
             // (see cru-terraform/github/CruGlobal/teams/web_engineering_js).


### PR DESCRIPTION
## Description

- Adds `.github/workflows/request-review.yml` — applying the **"Review"** label to a non-draft PR automatically requests a review from the `web-engineering-js` team
- Completes the work from #330: CODEOWNERS was removed there (it auto-requested all 5 owners on every PR); this restores review requests as an opt-in step when the author marks the PR ready
- Updates the PR template checklist: the "request a review from another person" item is replaced with applying the **Review** label
- Uses `pull_request_target` with no checkout, so it's safe for fork PRs
- No dependent PRs; no Jira ticket

No UI changes — screenshots N/A.

## Testing

- Create the **"Review"** label under Issues → Labels if it doesn't exist yet
- After merging, open a test PR and apply the **Review** label
- Check the Actions tab: "Request Team Review" should run and `web-engineering-js` should appear under Reviewers on the PR
- If the run fails with a permissions error, add a `REVIEW_BOT_TOKEN` repo secret (PAT with `repo` + `read:org`) — the workflow falls back to it automatically

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues (N/A — workflow YAML and template markdown only, no JS changes)
- [x] `yarn test --no-watch` passes locally (N/A — no app code changed)
- [ ] I have run `/agent-review` and addressed its findings before requesting a dev review
- [x] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from the team
- [ ] I have tested my changes on staging or development
- [x] I have cleaned up my commit history