### PR TITLE
[No-Jira] Fix crowdin workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -26,11 +26,9 @@ jobs:
       - name: 🌐 Extract Translations
         run: yarn extract
       - name: 🔤🔽 CrowdIn Translations Download
-        run: yarn crowdin download translations
+        run: yarn crowdin:download
         env:
           CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
-      - name: 🔤 Sort Translations
-        run: yarn crowdin:sort-translations
       - name: 🔀 Create PR
         uses: peter-evans/create-pull-request@v7
         env:


### PR DESCRIPTION
## Description

The crowdin workflow was using an old version of the run command. I updated it so the `--skip-untranslated-strings` actually works

## Testing

<!--
Please provide instructions for the reviewer of how to test your changes. What steps should they take to prove that the code fixed the bug or to see the new feature added?

Tips:
- Run the app locally with `yarn start:dev` (or check the deployed staging build once the "On Staging" label is applied).
- If the change affects the embed, test it via `embed/example.html` and confirm the tool still loads inside the iframe.
- Note the relevant tool/language (e.g. `data-book=kgp-us`, `data-lang=en`) the reviewer should use.

Example:
- Go to /#/en/kgp-us
- Navigate to the next page of the tool
- Check that the page renders correctly
-->

N/A

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [ ] I have run `/agent-review` and addressed its findings before requesting a dev review
- [x] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from a randomly-chosen team member
- [ ] I have tested my changes on staging or development
- [ ] I have cleaned up my commit history
