### PR TITLE
[GT-2823] - Add search input to navbar language selector

### DIFF
--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -103,10 +103,11 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 90%;
+  width: calc(100% - 32px);
+  max-width: 400px;
   background: #ffffff;
   border-radius: 6px;
-  height: 90%;
+  max-height: 70vh;
   display: flex;
   flex-direction: column;
 }
@@ -131,7 +132,7 @@
 #languageSwitchModal > div.modal-content > div.language-search {
   flex-shrink: 0;
   margin: 5px 0 0 0;
-  padding: 0 15px 0 5px;
+  padding: 0 10px;
 }
 
 #languageSwitchModal > div.modal-content > div.language-search > input {
@@ -162,27 +163,39 @@
 
 #languageSwitchModal > div.modal-content > ul.languages-grid {
   width: 100%;
-  overflow-y: scroll;
-  columns: 4;
-  column-gap: 10px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  min-height: 0;
   margin: 5px 0 0 0;
-  padding: 0 15px 5px 5px;
+  padding: 0 10px 10px;
+  box-sizing: border-box;
+  list-style: none;
+}
+
+#languageSwitchModal > div.modal-content > ul.languages-grid::-webkit-scrollbar {
+  width: 6px;
+}
+
+#languageSwitchModal
+  > div.modal-content
+  > ul.languages-grid::-webkit-scrollbar-thumb {
+  background-color: #c0c0c0;
+  border-radius: 3px;
 }
 
 #languageSwitchModal > div.modal-content > ul.languages-grid > li.language {
   height: 36px;
   width: 100%;
-  display: inline-flex;
-  margin: 4px;
+  display: flex;
+  margin: 0;
   padding: 0 8px;
   align-items: center;
   font-size: 13px;
   color: #555;
-  align-items: center;
   white-space: nowrap;
   overflow: hidden;
   border-radius: 4px;
-  border: 1px solid #efefef;
+  box-sizing: border-box;
   cursor: pointer;
 }
 
@@ -235,10 +248,6 @@
     margin: 10px 0px -10px;
     height: 36px;
     font-size: 14px;
-  }
-
-  #languageSwitchModal > div.modal-content > ul.languages-grid {
-    columns: 2;
   }
 }
 

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -107,7 +107,7 @@
   max-width: 400px;
   background: #ffffff;
   border-radius: 6px;
-  max-height: 70vh;
+  height: 70vh;
   display: flex;
   flex-direction: column;
 }
@@ -165,6 +165,7 @@
   width: 100%;
   overflow-y: auto;
   scrollbar-width: thin;
+  scrollbar-gutter: stable;
   min-height: 0;
   margin: 5px 0 0 0;
   padding: 0 10px 10px;

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -115,6 +115,7 @@
 #languageSwitchModal > div.modal-content > div.modal-close {
   width: 100%;
   height: 36px;
+  flex-shrink: 0;
   display: block;
   text-align: right;
   margin-top: 10px;
@@ -152,6 +153,7 @@
 }
 
 #languageSwitchModal > div.modal-content > div.no-language-results {
+  flex-shrink: 0;
   font-size: 13px;
   color: #555;
   text-align: center;

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -100,9 +100,9 @@
 #languageSwitchModal > div.modal-content {
   margin: 0;
   position: absolute;
-  top: 50%;
+  top: 15vh;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   width: calc(100% - 32px);
   max-width: 400px;
   background: #ffffff;

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -151,10 +151,13 @@
 }
 
 #languageSwitchModal > div.modal-content > div.no-language-results {
-  padding: 16px;
   font-size: 13px;
   color: #555;
   text-align: center;
+}
+
+#languageSwitchModal > div.modal-content > div.no-language-results.has-message {
+  padding: 16px;
 }
 
 #languageSwitchModal > div.modal-content > ul.languages-grid {

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -128,6 +128,35 @@
   font-weight: 400;
 }
 
+#languageSwitchModal > div.modal-content > div.language-search {
+  flex-shrink: 0;
+  margin: 5px 0 0 0;
+  padding: 0 15px 0 5px;
+}
+
+#languageSwitchModal > div.modal-content > div.language-search > input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px;
+  box-sizing: border-box;
+  font-size: 13px;
+  color: #555;
+  border: 1px solid #efefef;
+  border-radius: 4px;
+  outline: none;
+}
+
+#languageSwitchModal > div.modal-content > div.language-search > input:focus {
+  border-color: #cccccc;
+}
+
+#languageSwitchModal > div.modal-content > div.no-language-results {
+  padding: 16px;
+  font-size: 13px;
+  color: #555;
+  text-align: center;
+}
+
 #languageSwitchModal > div.modal-content > ul.languages-grid {
   width: 100%;
   overflow-y: scroll;

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -78,14 +78,26 @@
     <div class="modal-close">
       <i class="fas fa-times" (click)="onSwitchLanguage()"></i>
     </div>
+    <div class="language-search">
+      <input
+        type="search"
+        dir="auto"
+        [(ngModel)]="languageSearchText"
+        [placeholder]="'Search languages' | i18nextEager"
+        [attr.aria-label]="'Search languages' | i18nextEager"
+      />
+    </div>
     <ul class="languages-grid">
       <li
         class="language"
-        *ngFor="let lang of availableLangs"
+        *ngFor="let lang of filteredLangs"
         (click)="onSelectLanguage(lang.code)"
       >
         {{ lang.name }}
       </li>
     </ul>
+    <div class="no-language-results" *ngIf="filteredLangs.length === 0">
+      {{ 'No languages found' | i18nextEager }}
+    </div>
   </div>
 </div>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -96,8 +96,15 @@
         {{ lang.name }}
       </li>
     </ul>
-    <div class="no-language-results" *ngIf="filteredLangs.length === 0">
-      {{ 'No languages found' | i18nextEager }}
+    <div
+      class="no-language-results"
+      role="status"
+      aria-live="polite"
+      [class.has-message]="filteredLangs.length === 0"
+    >
+      <ng-container *ngIf="filteredLangs.length === 0">
+        {{ 'No languages found' | i18nextEager }}
+      </ng-container>
     </div>
   </div>
 </div>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -80,9 +80,11 @@
     </div>
     <div class="language-search">
       <input
+        #languageSearchInput
         type="search"
         dir="auto"
-        [(ngModel)]="languageSearchText"
+        [ngModel]="languageSearchText"
+        (ngModelChange)="onLanguageSearchTextChange($event)"
         [placeholder]="'Search languages' | i18nextEager"
         [attr.aria-label]="'Search languages' | i18nextEager"
       />
@@ -100,9 +102,9 @@
       class="no-language-results"
       role="status"
       aria-live="polite"
-      [class.has-message]="filteredLangs.length === 0"
+      [class.has-message]="showNoLanguagesMessage"
     >
-      <ng-container *ngIf="filteredLangs.length === 0">
+      <ng-container *ngIf="showNoLanguagesMessage">
         {{ 'No languages found' | i18nextEager }}
       </ng-container>
     </div>

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -9,6 +9,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { I18NextModule } from 'angular-i18next';
+import { NEVER } from 'rxjs';
 import { mockPageComponent } from '../_tests/mocks';
 import { CommonService } from '../services/common.service';
 import { DashboardComponent } from './dashboard.component';
@@ -66,6 +67,19 @@ describe('DashboardComponent', () => {
     expect(component.availableLangs[0].code).toEqual('zh-Hant');
   }));
 
+  it('prepareLanguageSwitcher() should ignore languagesReady emissions before languages load', fakeAsync(() => {
+    spyOn(component.commonService, 'getLanguages').and.returnValue(NEVER);
+    component['prepareLanguageSwitcher']();
+
+    // awaitBooks re-emits languagesReady when dashboard data arrives, which
+    // can happen before the languages request resolves.
+    component['_languagesReady'].next();
+    tick();
+
+    expect(component.availableLangs).toBeUndefined();
+    expect(component.filteredLangs).toEqual([]);
+  }));
+
   it('filteredLangs should filter by search text', fakeAsync(() => {
     component['_languagesData'] = [
       mockPageComponent.languageEnglish,
@@ -77,22 +91,33 @@ describe('DashboardComponent', () => {
     component['prepareLanguageSwitcher']();
     tick();
 
-    component.languageSearchText = '';
     expect(component.filteredLangs.length).toEqual(3);
+    expect(component.showNoLanguagesMessage).toBeFalse();
 
     // Matches the name shown in the selector
-    component.languageSearchText = 'germ';
+    component.onLanguageSearchTextChange('germ');
     expect(component.filteredLangs.map((l) => l.code)).toEqual(['de']);
 
-    component.languageSearchText = 'no such language';
+    component.onLanguageSearchTextChange('no such language');
     expect(component.filteredLangs.length).toEqual(0);
+    expect(component.showNoLanguagesMessage).toBeTrue();
   }));
 
-  it('onSwitchLanguage() should clear the search text', () => {
-    component.languageSearchText = 'germ';
+  it('onSwitchLanguage() should clear the search text and restore the full list', fakeAsync(() => {
+    component['_languagesData'] = [mockPageComponent.languageGerman];
+    component.languagesWithLessons = null;
+    spyOn(component, 'isLessonsPage').and.returnValue(false);
+    component['prepareLanguageSwitcher']();
+    tick();
+
+    component.onLanguageSearchTextChange('no such language');
+    expect(component.filteredLangs.length).toEqual(0);
+
     component.onSwitchLanguage();
     expect(component.languageSearchText).toEqual('');
-  });
+    expect(component.filteredLangs.length).toEqual(1);
+    tick();
+  }));
 
   it('setDisplayLanguage() should match case-insensitively and store API correct casing', () => {
     component['_languagesData'] = [

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -6,6 +6,7 @@ import {
   tick,
   waitForAsync
 } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { I18NextModule } from 'angular-i18next';
 import { mockPageComponent } from '../_tests/mocks';
@@ -19,7 +20,12 @@ describe('DashboardComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [DashboardComponent],
-      imports: [HttpClientModule, RouterTestingModule, I18NextModule.forRoot()],
+      imports: [
+        HttpClientModule,
+        FormsModule,
+        RouterTestingModule,
+        I18NextModule.forRoot()
+      ],
       providers: [CommonService]
     }).compileComponents();
   }));
@@ -59,6 +65,38 @@ describe('DashboardComponent', () => {
     expect(component.availableLangs.length).toEqual(1);
     expect(component.availableLangs[0].code).toEqual('zh-Hant');
   }));
+
+  it('filteredLangs should filter by search text, matching names across languages', fakeAsync(() => {
+    component['_languagesData'] = [
+      mockPageComponent.languageEnglish,
+      mockPageComponent.languageGerman,
+      mockPageComponent.languageChineseTraditional
+    ];
+    component.languagesWithLessons = null;
+    spyOn(component, 'isLessonsPage').and.returnValue(false);
+    component['prepareLanguageSwitcher']();
+    tick();
+
+    component.languageSearchText = '';
+    expect(component.filteredLangs.length).toEqual(3);
+
+    // Matches the name shown in the selector
+    component.languageSearchText = 'germ';
+    expect(component.filteredLangs.map((l) => l.code)).toEqual(['de']);
+
+    // Matches the language's own name for itself
+    component.languageSearchText = 'Deutsch';
+    expect(component.filteredLangs.map((l) => l.code)).toEqual(['de']);
+
+    component.languageSearchText = 'no such language';
+    expect(component.filteredLangs.length).toEqual(0);
+  }));
+
+  it('onSwitchLanguage() should clear the search text', () => {
+    component.languageSearchText = 'germ';
+    component.onSwitchLanguage();
+    expect(component.languageSearchText).toEqual('');
+  });
 
   it('setDisplayLanguage() should match case-insensitively and store API correct casing', () => {
     component['_languagesData'] = [

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -66,7 +66,7 @@ describe('DashboardComponent', () => {
     expect(component.availableLangs[0].code).toEqual('zh-Hant');
   }));
 
-  it('filteredLangs should filter by search text, matching names across languages', fakeAsync(() => {
+  it('filteredLangs should filter by search text', fakeAsync(() => {
     component['_languagesData'] = [
       mockPageComponent.languageEnglish,
       mockPageComponent.languageGerman,
@@ -82,10 +82,6 @@ describe('DashboardComponent', () => {
 
     // Matches the name shown in the selector
     component.languageSearchText = 'germ';
-    expect(component.filteredLangs.map((l) => l.code)).toEqual(['de']);
-
-    // Matches the language's own name for itself
-    component.languageSearchText = 'Deutsch';
     expect(component.filteredLangs.map((l) => l.code)).toEqual(['de']);
 
     component.languageSearchText = 'no such language';

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -11,6 +11,10 @@ import {
   ToolType
 } from '../services/xml-parser-service/xml-parser.service';
 import { getUrlResourceType } from '../shared/getUrlResourceType';
+import {
+  buildLanguageSearchKey,
+  languageMatchesSearch
+} from '../shared/language-search';
 
 interface Language {
   id: string;
@@ -53,7 +57,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
   dispLanguageName: string;
   dispLanguageDirection: string;
   langSwitchOn: boolean;
-  availableLangs: { code: string; name: string }[];
+  availableLangs: { code: string; name: string; searchKey: string }[];
+  languageSearchText = '';
   resourceTypes = [ResourceType.Tract, ResourceType.CYOA, ResourceType.Lesson];
 
   constructor(
@@ -109,7 +114,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
           })
           .map(({ attributes }) => ({
             code: attributes.code,
-            name: attributes.name
+            name: attributes.name,
+            searchKey: buildLanguageSearchKey(
+              attributes.code,
+              attributes.name,
+              this.dispLanguageCode
+            )
           }));
       });
 
@@ -203,6 +213,16 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   onSwitchLanguage(): void {
     this.langSwitchOn = !this.langSwitchOn;
+    this.languageSearchText = '';
+  }
+
+  get filteredLangs(): { code: string; name: string; searchKey: string }[] {
+    if (!this.availableLangs) {
+      return [];
+    }
+    return this.availableLangs.filter((lang) =>
+      languageMatchesSearch(lang.searchKey, this.languageSearchText)
+    );
   }
 
   onSelectLanguage(pLangCode: string): void {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -13,7 +13,7 @@ import {
 import { getUrlResourceType } from '../shared/getUrlResourceType';
 import {
   buildLanguageSearchKey,
-  languageMatchesSearch
+  filterLanguages
 } from '../shared/language-search';
 
 interface Language {
@@ -220,8 +220,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (!this.availableLangs) {
       return [];
     }
-    return this.availableLangs.filter((lang) =>
-      languageMatchesSearch(lang.searchKey, this.languageSearchText)
+    return filterLanguages(
+      this.availableLangs,
+      (lang) => lang.searchKey,
+      this.languageSearchText
     );
   }
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,4 +1,11 @@
-import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  Inject,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { I18NEXT_SERVICE, ITranslationService } from 'angular-i18next';
 import { Subject } from 'rxjs';
@@ -40,6 +47,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private _languageChanged = new Subject<void>();
   private _prepareDataForLanguage = new Subject<void>();
   private _languagesData: Language[];
+  private _languageSearchKeys = new Map<string, string>();
+
+  @ViewChild('languageSearchInput')
+  private languageSearchInput: ElementRef<HTMLInputElement>;
 
   private readonly _toolsRoute = 'tools';
   private readonly _lessonsRoute = 'lessons';
@@ -57,7 +68,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
   dispLanguageName: string;
   dispLanguageDirection: string;
   langSwitchOn: boolean;
-  availableLangs: { code: string; name: string; searchKey: string }[];
+  availableLangs: { code: string; name: string }[];
+  filteredLangs: { code: string; name: string }[] = [];
+  showNoLanguagesMessage = false;
   languageSearchText = '';
   resourceTypes = [ResourceType.Tract, ResourceType.CYOA, ResourceType.Lesson];
 
@@ -103,6 +116,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
         delay(0)
       )
       .subscribe(() => {
+        // awaitBooks can re-emit languagesReady before the languages request
+        // has resolved; ignore emissions until the data is actually here.
+        if (!this._languagesData) {
+          return;
+        }
+
         const shouldFilterLanguages =
           this.languagesWithLessons && this.isLessonsPage();
 
@@ -114,13 +133,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
           })
           .map(({ attributes }) => ({
             code: attributes.code,
-            name: attributes.name,
-            searchKey: buildLanguageSearchKey(
-              attributes.code,
-              attributes.name,
-              this.dispLanguageCode
-            )
+            name: attributes.name
           }));
+        this.updateFilteredLangs();
       });
 
     if (!this._languagesData) {
@@ -214,17 +229,46 @@ export class DashboardComponent implements OnInit, OnDestroy {
   onSwitchLanguage(): void {
     this.langSwitchOn = !this.langSwitchOn;
     this.languageSearchText = '';
+    this.updateFilteredLangs();
+    if (this.langSwitchOn) {
+      setTimeout(() => this.languageSearchInput?.nativeElement.focus());
+    }
   }
 
-  get filteredLangs(): { code: string; name: string; searchKey: string }[] {
-    if (!this.availableLangs) {
-      return [];
+  onLanguageSearchTextChange(searchText: string): void {
+    this.languageSearchText = searchText;
+    this.updateFilteredLangs();
+  }
+
+  // Recomputed on demand instead of a getter so the filter doesn't re-run on
+  // every change-detection cycle.
+  private updateFilteredLangs(): void {
+    this.filteredLangs = this.availableLangs
+      ? filterLanguages(
+          this.availableLangs,
+          (lang) => this.getLanguageSearchKey(lang),
+          this.languageSearchText
+        )
+      : [];
+    this.showNoLanguagesMessage =
+      this.availableLangs?.length > 0 && this.filteredLangs.length === 0;
+  }
+
+  // Search keys are built lazily on the first non-empty search and cached, so
+  // opening the dashboard never pays the Intl.DisplayNames cost for the full
+  // language list up front.
+  private getLanguageSearchKey(lang: { code: string; name: string }): string {
+    const cacheKey = `${lang.code}|${this.dispLanguageCode}`;
+    let searchKey = this._languageSearchKeys.get(cacheKey);
+    if (searchKey === undefined) {
+      searchKey = buildLanguageSearchKey(
+        lang.code,
+        lang.name,
+        this.dispLanguageCode
+      );
+      this._languageSearchKeys.set(cacheKey, searchKey);
     }
-    return filterLanguages(
-      this.availableLangs,
-      (lang) => lang.searchKey,
-      this.languageSearchText
-    );
+    return searchKey;
   }
 
   onSelectLanguage(pLangCode: string): void {

--- a/src/app/page/page.component.css
+++ b/src/app/page/page.component.css
@@ -129,7 +129,8 @@ p {
   border-color: #999;
 }
 
-#languageList .no-language-results {
+#languageList .no-language-results span {
+  display: block;
   padding: 4px 16px;
   line-height: 1.25;
 }

--- a/src/app/page/page.component.css
+++ b/src/app/page/page.component.css
@@ -110,6 +110,30 @@ p {
   background-color: #f0f0f0;
 }
 
+#languageList .language-search {
+  padding: 0 16px 8px;
+}
+
+#languageList .language-search input {
+  width: 100%;
+  padding: 6px 12px;
+  box-sizing: border-box;
+  font-size: inherit;
+  line-height: 1.25;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  outline: none;
+}
+
+#languageList .language-search input:focus {
+  border-color: #999;
+}
+
+#languageList .no-language-results {
+  padding: 4px 16px;
+  line-height: 1.25;
+}
+
 #languageList ul {
   columns: 2;
   margin: 0;

--- a/src/app/page/page.component.css
+++ b/src/app/page/page.component.css
@@ -135,17 +135,17 @@ p {
   line-height: 1.25;
 }
 
+#languageList .language-list {
+  overflow: hidden;
+}
+
 #languageList ul {
   margin: 0;
   padding: 0;
-  max-height: 320px;
+  max-height: 100%;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-gutter: stable;
-}
-
-#languageList ul.fixed-height {
-  height: 320px;
 }
 
 #languageList ul::-webkit-scrollbar {

--- a/src/app/page/page.component.css
+++ b/src/app/page/page.component.css
@@ -141,6 +141,11 @@ p {
   max-height: 320px;
   overflow-y: auto;
   scrollbar-width: thin;
+  scrollbar-gutter: stable;
+}
+
+#languageList ul.fixed-height {
+  height: 320px;
 }
 
 #languageList ul::-webkit-scrollbar {

--- a/src/app/page/page.component.css
+++ b/src/app/page/page.component.css
@@ -136,9 +136,20 @@ p {
 }
 
 #languageList ul {
-  columns: 2;
   margin: 0;
   padding: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+#languageList ul::-webkit-scrollbar {
+  width: 6px;
+}
+
+#languageList ul::-webkit-scrollbar-thumb {
+  background-color: #c0c0c0;
+  border-radius: 3px;
 }
 
 #languageList li {
@@ -152,12 +163,6 @@ p {
 #languageList li:hover {
   background-color: white;
   cursor: pointer;
-}
-
-@media screen and (min-width: 550px) {
-  #languageList ul {
-    columns: 3;
-  }
 }
 
 @media screen and (max-width: 550px) {

--- a/src/app/page/page.component.html
+++ b/src/app/page/page.component.html
@@ -45,7 +45,7 @@
               [attr.aria-label]="'Search languages' | i18nextEager"
             />
           </div>
-          <ul>
+          <ul [class.fixed-height]="availableLanguages.length > 11">
             <li
               class="ng-binding"
               dir="ltr"

--- a/src/app/page/page.component.html
+++ b/src/app/page/page.component.html
@@ -46,24 +46,27 @@
               [attr.aria-label]="'Search languages' | i18nextEager"
             />
           </div>
-          <ul [class.fixed-height]="availableLanguages.length > 11">
-            <li
-              class="ng-binding"
-              dir="ltr"
-              (click)="selectLanguage(lang, true)"
-              *ngFor="let lang of filteredLanguages"
-            >
-              {{ lang.attributes.name }}
-            </li>
-          </ul>
-          <div class="no-language-results" role="status" aria-live="polite">
-            <span
-              *ngIf="
-                availableLanguages.length > 0 && filteredLanguages.length === 0
-              "
-            >
-              {{ 'No languages found' | i18nextEager }}
-            </span>
+          <div class="language-list" [style.height.px]="languageListHeightPx">
+            <ul>
+              <li
+                class="ng-binding"
+                dir="ltr"
+                (click)="selectLanguage(lang, true)"
+                *ngFor="let lang of filteredLanguages"
+              >
+                {{ lang.attributes.name }}
+              </li>
+            </ul>
+            <div class="no-language-results" role="status" aria-live="polite">
+              <span
+                *ngIf="
+                  availableLanguages.length > 0 &&
+                  filteredLanguages.length === 0
+                "
+              >
+                {{ 'No languages found' | i18nextEager }}
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/page/page.component.html
+++ b/src/app/page/page.component.html
@@ -36,16 +36,31 @@
       </div>
       <div id="languageList" class="py25 ng-hide" *ngIf="languagesVisible">
         <div class="mw568">
+          <div class="language-search">
+            <input
+              type="search"
+              dir="auto"
+              [(ngModel)]="languageSearchText"
+              [placeholder]="'Search languages' | i18nextEager"
+              [attr.aria-label]="'Search languages' | i18nextEager"
+            />
+          </div>
           <ul>
             <li
               class="ng-binding"
               dir="ltr"
               (click)="selectLanguage(lang, true)"
-              *ngFor="let lang of availableLanguages"
+              *ngFor="let lang of filteredLanguages"
             >
               {{ lang.attributes.name }}
             </li>
           </ul>
+          <div
+            class="no-language-results"
+            *ngIf="filteredLanguages.length === 0"
+          >
+            {{ 'No languages found' | i18nextEager }}
+          </div>
         </div>
       </div>
     </header>

--- a/src/app/page/page.component.html
+++ b/src/app/page/page.component.html
@@ -55,11 +55,10 @@
               {{ lang.attributes.name }}
             </li>
           </ul>
-          <div
-            class="no-language-results"
-            *ngIf="filteredLanguages.length === 0"
-          >
-            {{ 'No languages found' | i18nextEager }}
+          <div class="no-language-results" role="status" aria-live="polite">
+            <span *ngIf="filteredLanguages.length === 0">
+              {{ 'No languages found' | i18nextEager }}
+            </span>
           </div>
         </div>
       </div>

--- a/src/app/page/page.component.html
+++ b/src/app/page/page.component.html
@@ -38,6 +38,7 @@
         <div class="mw568">
           <div class="language-search">
             <input
+              #languageSearchInput
               type="search"
               dir="auto"
               [(ngModel)]="languageSearchText"
@@ -56,7 +57,11 @@
             </li>
           </ul>
           <div class="no-language-results" role="status" aria-live="polite">
-            <span *ngIf="filteredLanguages.length === 0">
+            <span
+              *ngIf="
+                availableLanguages.length > 0 && filteredLanguages.length === 0
+              "
+            >
               {{ 'No languages found' | i18nextEager }}
             </span>
           </div>

--- a/src/app/page/page.component.spec.ts
+++ b/src/app/page/page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { I18NextModule } from 'angular-i18next';
@@ -59,7 +60,12 @@ describe('PageComponent', () => {
     pageService = new PageService();
     TestBed.configureTestingModule({
       declarations: [PageComponent],
-      imports: [HttpClientModule, RouterTestingModule, I18NextModule.forRoot()],
+      imports: [
+        HttpClientModule,
+        FormsModule,
+        RouterTestingModule,
+        I18NextModule.forRoot()
+      ],
       providers: [
         CommonService,
         LoaderService,
@@ -124,6 +130,37 @@ describe('PageComponent', () => {
     component.languagesVisible = false;
     component.onToggleLanguageSelect();
     expect(component.languagesVisible).toBeTrue();
+  });
+
+  it('onToggleLanguageSelect() should clear the search text', () => {
+    component.languageSearchText = 'germ';
+    component.onToggleLanguageSelect();
+    expect(component.languageSearchText).toEqual('');
+  });
+
+  it('filteredLanguages should filter by search text, matching names across languages', () => {
+    component.availableLanguages = [
+      mockPageComponent.languageEnglish,
+      mockPageComponent.languageGerman
+    ];
+
+    component.languageSearchText = '';
+    expect(component.filteredLanguages.length).toEqual(2);
+
+    // Matches the name shown in the selector
+    component.languageSearchText = 'eng';
+    expect(component.filteredLanguages).toEqual([
+      mockPageComponent.languageEnglish
+    ]);
+
+    // Matches the language's own name for itself
+    component.languageSearchText = 'Deutsch';
+    expect(component.filteredLanguages).toEqual([
+      mockPageComponent.languageGerman
+    ]);
+
+    component.languageSearchText = 'no such language';
+    expect(component.filteredLanguages.length).toEqual(0);
   });
 
   it('onPreviousPage() on page 0', () => {

--- a/src/app/page/page.component.spec.ts
+++ b/src/app/page/page.component.spec.ts
@@ -153,8 +153,8 @@ describe('PageComponent', () => {
       mockPageComponent.languageEnglish
     ]);
 
-    // Matches the language's own name for itself
-    component.languageSearchText = 'Deutsch';
+    // Matches the API-provided language name
+    component.languageSearchText = 'german';
     expect(component.filteredLanguages).toEqual([
       mockPageComponent.languageGerman
     ]);

--- a/src/app/page/page.component.spec.ts
+++ b/src/app/page/page.component.spec.ts
@@ -163,6 +163,42 @@ describe('PageComponent', () => {
     expect(component.filteredLanguages.length).toEqual(0);
   });
 
+  it('filteredLanguages should reuse cached search keys on repeated reads', () => {
+    component.availableLanguages = [
+      mockPageComponent.languageEnglish,
+      mockPageComponent.languageGerman
+    ];
+    component.languageSearchText = 'eng';
+    const displayNamesSpy = spyOn(Intl, 'DisplayNames').and.callThrough();
+
+    expect(component.filteredLanguages).toEqual([
+      mockPageComponent.languageEnglish
+    ]);
+    const callsAfterFirstRead = displayNamesSpy.calls.count();
+    expect(callsAfterFirstRead).toBeGreaterThan(0);
+
+    expect(component.filteredLanguages).toEqual([
+      mockPageComponent.languageEnglish
+    ]);
+    expect(displayNamesSpy.calls.count()).toEqual(callsAfterFirstRead);
+  });
+
+  it('filteredLanguages should build new search keys when the display locale changes', () => {
+    component.availableLanguages = [
+      mockPageComponent.languageEnglish,
+      mockPageComponent.languageGerman
+    ];
+    component.languageSearchText = 'eng';
+    const displayNamesSpy = spyOn(Intl, 'DisplayNames').and.callThrough();
+
+    expect(component.filteredLanguages.length).toEqual(1);
+    const callsForFirstLocale = displayNamesSpy.calls.count();
+
+    component._pageParams.langId = 'de';
+    expect(component.filteredLanguages.length).toEqual(1);
+    expect(displayNamesSpy.calls.count()).toBeGreaterThan(callsForFirstLocale);
+  });
+
   it('onPreviousPage() on page 0', () => {
     component.onPreviousPage();
     expect(router.navigate).toHaveBeenCalledTimes(0);

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -261,6 +261,19 @@ export class PageComponent implements OnInit, OnDestroy {
     );
   }
 
+  // The list keeps the height of the full (unfiltered) list while open, so
+  // filtering never changes the page height — otherwise the document scrollbar
+  // can appear/disappear mid-search and nudge the centered layout sideways.
+  // 28px = the rendered #languageList li height (2 * 4px padding + 20px line).
+  get languageListHeightPx(): number {
+    const rowHeightPx = 28;
+    const maxHeightPx = 320;
+    return Math.min(
+      maxHeightPx,
+      (this.availableLanguages?.length || 0) * rowHeightPx
+    );
+  }
+
   // Keys live in an external Map because availableLanguages holds shared
   // parsed Language models this component must not mutate (unlike the
   // dashboard, which owns its mapped objects and can build keys eagerly).

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -254,6 +254,9 @@ export class PageComponent implements OnInit, OnDestroy {
     );
   }
 
+  // Keys live in an external Map because availableLanguages holds shared
+  // parsed Language models this component must not mutate (unlike the
+  // dashboard, which owns its mapped objects and can build keys eagerly).
   private getLanguageSearchKey(lang: Language): string {
     const cacheKey = `${lang.id}|${this._pageParams.langId}`;
     let searchKey = this._languageSearchKeys.get(cacheKey);
@@ -1010,6 +1013,7 @@ export class PageComponent implements OnInit, OnDestroy {
     this._pageBookSubPagesManifest = [];
     this._pageBookSubPages = [];
     this._visibleHiddenPageIds.clear();
+    this._languageSearchKeys.clear();
     this.availableLanguages = [];
     this.selectedBookName = '';
     this.languagesVisible = false;

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -1,10 +1,12 @@
 import { ViewportScroller } from '@angular/common';
 import {
   Component,
+  ElementRef,
   HostListener,
   Inject,
   OnDestroy,
   OnInit,
+  ViewChild,
   ViewEncapsulation
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -117,6 +119,9 @@ export class PageComponent implements OnInit, OnDestroy {
   private _selectedLanguage: Language;
   private _languageSearchKeys = new Map<string, string>();
   private liveShareSubscription: ActionCable.Channel;
+
+  @ViewChild('languageSearchInput')
+  private languageSearchInput: ElementRef<HTMLInputElement>;
 
   pagesLoaded: boolean;
   selectedLang: string;
@@ -240,6 +245,9 @@ export class PageComponent implements OnInit, OnDestroy {
   onToggleLanguageSelect(): void {
     this.languagesVisible = !this.languagesVisible;
     this.languageSearchText = '';
+    if (this.languagesVisible) {
+      setTimeout(() => this.languageSearchInput?.nativeElement.focus());
+    }
   }
 
   get filteredLanguages(): Language[] {
@@ -259,7 +267,7 @@ export class PageComponent implements OnInit, OnDestroy {
   private getLanguageSearchKey(lang: Language): string {
     const cacheKey = `${lang.id}|${this._pageParams.langId}`;
     let searchKey = this._languageSearchKeys.get(cacheKey);
-    if (!searchKey) {
+    if (searchKey === undefined) {
       searchKey = buildLanguageSearchKey(
         lang.attributes.code,
         lang.attributes.name,

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -29,7 +29,7 @@ import {
 } from '../services/xml-parser-service/xml-parser.service';
 import {
   buildLanguageSearchKey,
-  languageMatchesSearch
+  filterLanguages
 } from '../shared/language-search';
 import { IPageParameters } from './model/page-parameters';
 import { PageService } from './service/page-service.service';
@@ -246,11 +246,10 @@ export class PageComponent implements OnInit, OnDestroy {
     if (!this.availableLanguages) {
       return [];
     }
-    return this.availableLanguages.filter((lang) =>
-      languageMatchesSearch(
-        this.getLanguageSearchKey(lang),
-        this.languageSearchText
-      )
+    return filterLanguages(
+      this.availableLanguages,
+      (lang) => this.getLanguageSearchKey(lang),
+      this.languageSearchText
     );
   }
 

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -27,6 +27,10 @@ import {
   XmlParserData,
   godToolsParser
 } from '../services/xml-parser-service/xml-parser.service';
+import {
+  buildLanguageSearchKey,
+  languageMatchesSearch
+} from '../shared/language-search';
 import { IPageParameters } from './model/page-parameters';
 import { PageService } from './service/page-service.service';
 
@@ -111,12 +115,14 @@ export class PageComponent implements OnInit, OnDestroy {
   private _pageBookSubPages: Page[];
   private _visibleHiddenPageIds: Set<string>; // Track temporarily visible hidden pages
   private _selectedLanguage: Language;
+  private _languageSearchKeys = new Map<string, string>();
   private liveShareSubscription: ActionCable.Channel;
 
   pagesLoaded: boolean;
   selectedLang: string;
   availableLanguages: Language[];
   languagesVisible: boolean;
+  languageSearchText = '';
   resourceType: ResourceType;
   selectedBookName: string;
   activePage: Page;
@@ -233,6 +239,33 @@ export class PageComponent implements OnInit, OnDestroy {
 
   onToggleLanguageSelect(): void {
     this.languagesVisible = !this.languagesVisible;
+    this.languageSearchText = '';
+  }
+
+  get filteredLanguages(): Language[] {
+    if (!this.availableLanguages) {
+      return [];
+    }
+    return this.availableLanguages.filter((lang) =>
+      languageMatchesSearch(
+        this.getLanguageSearchKey(lang),
+        this.languageSearchText
+      )
+    );
+  }
+
+  private getLanguageSearchKey(lang: Language): string {
+    const cacheKey = `${lang.id}|${this._pageParams.langId}`;
+    let searchKey = this._languageSearchKeys.get(cacheKey);
+    if (!searchKey) {
+      searchKey = buildLanguageSearchKey(
+        lang.attributes.code,
+        lang.attributes.name,
+        this._pageParams.langId
+      );
+      this._languageSearchKeys.set(cacheKey, searchKey);
+    }
+    return searchKey;
   }
 
   private getVisiblePages(
@@ -980,6 +1013,7 @@ export class PageComponent implements OnInit, OnDestroy {
     this.availableLanguages = [];
     this.selectedBookName = '';
     this.languagesVisible = false;
+    this.languageSearchText = '';
     this.activePage = null;
     this.activePageOrder = 0;
     this.totalPages = 0;

--- a/src/app/shared/language-search.spec.ts
+++ b/src/app/shared/language-search.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildLanguageSearchKey,
+  filterLanguages,
   languageMatchesSearch,
   normalizeLanguageText
 } from './language-search';
@@ -68,6 +69,30 @@ describe('language-search', () => {
 
     it('rejects non-matching queries', () => {
       expect(languageMatchesSearch(key, 'swahili')).toBeFalse();
+    });
+  });
+
+  describe('filterLanguages', () => {
+    const languages = [
+      { name: 'Spanish', searchKey: buildLanguageSearchKey('es', 'Spanish') },
+      { name: 'German', searchKey: buildLanguageSearchKey('de', 'German') }
+    ];
+
+    it('returns the full list when the query is empty or whitespace', () => {
+      expect(filterLanguages(languages, (lang) => lang.searchKey, '')).toEqual(
+        languages
+      );
+      expect(
+        filterLanguages(languages, (lang) => lang.searchKey, '   ')
+      ).toEqual(languages);
+    });
+
+    it('keeps only matching languages', () => {
+      expect(
+        filterLanguages(languages, (lang) => lang.searchKey, 'ESPAÑOL').map(
+          (lang) => lang.name
+        )
+      ).toEqual(['Spanish']);
     });
   });
 });

--- a/src/app/shared/language-search.spec.ts
+++ b/src/app/shared/language-search.spec.ts
@@ -1,0 +1,73 @@
+import {
+  buildLanguageSearchKey,
+  languageMatchesSearch,
+  normalizeLanguageText
+} from './language-search';
+
+describe('language-search', () => {
+  describe('normalizeLanguageText', () => {
+    it('lowercases and trims', () => {
+      expect(normalizeLanguageText('  English ')).toEqual('english');
+    });
+
+    it('removes diacritics', () => {
+      expect(normalizeLanguageText('Español')).toEqual('espanol');
+      expect(normalizeLanguageText('Français')).toEqual('francais');
+    });
+
+    it('handles empty input', () => {
+      expect(normalizeLanguageText('')).toEqual('');
+      expect(normalizeLanguageText(null)).toEqual('');
+    });
+  });
+
+  describe('buildLanguageSearchKey', () => {
+    it('matches the name reported by the API', () => {
+      const key = buildLanguageSearchKey('es', 'Spanish', 'en');
+      expect(languageMatchesSearch(key, 'span')).toBeTrue();
+    });
+
+    it('matches the language code', () => {
+      const key = buildLanguageSearchKey('es', 'Spanish', 'en');
+      expect(languageMatchesSearch(key, 'es')).toBeTrue();
+    });
+
+    it("matches the language's own name for itself", () => {
+      const key = buildLanguageSearchKey('es', 'Spanish', 'en');
+      expect(languageMatchesSearch(key, 'español')).toBeTrue();
+      expect(languageMatchesSearch(key, 'espanol')).toBeTrue();
+    });
+
+    it('matches the name localized to the displayed language', () => {
+      const key = buildLanguageSearchKey('en', 'English', 'fr');
+      expect(languageMatchesSearch(key, 'anglais')).toBeTrue();
+    });
+
+    it('matches non-Latin names', () => {
+      const key = buildLanguageSearchKey('zh-Hans', 'Chinese (Simplified)');
+      expect(languageMatchesSearch(key, '中文')).toBeTrue();
+    });
+
+    it('does not throw on codes Intl cannot handle', () => {
+      const key = buildLanguageSearchKey('not a code!', 'Mystery', 'en');
+      expect(languageMatchesSearch(key, 'mystery')).toBeTrue();
+    });
+  });
+
+  describe('languageMatchesSearch', () => {
+    const key = buildLanguageSearchKey('de', 'German', 'en');
+
+    it('matches everything when the query is empty or whitespace', () => {
+      expect(languageMatchesSearch(key, '')).toBeTrue();
+      expect(languageMatchesSearch(key, '   ')).toBeTrue();
+    });
+
+    it('is case-insensitive', () => {
+      expect(languageMatchesSearch(key, 'GERMAN')).toBeTrue();
+    });
+
+    it('rejects non-matching queries', () => {
+      expect(languageMatchesSearch(key, 'swahili')).toBeFalse();
+    });
+  });
+});

--- a/src/app/shared/language-search.spec.ts
+++ b/src/app/shared/language-search.spec.ts
@@ -1,11 +1,13 @@
 import {
   buildLanguageSearchKey,
   filterLanguages,
-  languageMatchesSearch,
   normalizeLanguageText
 } from './language-search';
 
 describe('language-search', () => {
+  const matches = (searchKey: string, query: string): boolean =>
+    filterLanguages([searchKey], (key) => key, query).length === 1;
+
   describe('normalizeLanguageText', () => {
     it('lowercases and trims', () => {
       expect(normalizeLanguageText('  English ')).toEqual('english');
@@ -25,57 +27,50 @@ describe('language-search', () => {
   describe('buildLanguageSearchKey', () => {
     it('matches the name reported by the API', () => {
       const key = buildLanguageSearchKey('es', 'Spanish', 'en');
-      expect(languageMatchesSearch(key, 'span')).toBeTrue();
+      expect(matches(key, 'span')).toBeTrue();
     });
 
     it('matches the language code', () => {
       const key = buildLanguageSearchKey('es', 'Spanish', 'en');
-      expect(languageMatchesSearch(key, 'es')).toBeTrue();
+      expect(matches(key, 'es')).toBeTrue();
     });
 
     it("matches the language's own name for itself", () => {
       const key = buildLanguageSearchKey('es', 'Spanish', 'en');
-      expect(languageMatchesSearch(key, 'español')).toBeTrue();
-      expect(languageMatchesSearch(key, 'espanol')).toBeTrue();
+      expect(matches(key, 'español')).toBeTrue();
+      expect(matches(key, 'espanol')).toBeTrue();
     });
 
     it('matches the name localized to the displayed language', () => {
       const key = buildLanguageSearchKey('en', 'English', 'fr');
-      expect(languageMatchesSearch(key, 'anglais')).toBeTrue();
+      expect(matches(key, 'anglais')).toBeTrue();
     });
 
     it('matches non-Latin names', () => {
-      const key = buildLanguageSearchKey('zh-Hans', 'Chinese (Simplified)');
-      expect(languageMatchesSearch(key, '中文')).toBeTrue();
+      const key = buildLanguageSearchKey(
+        'zh-Hans',
+        'Chinese (Simplified)',
+        'en'
+      );
+      expect(matches(key, '中文')).toBeTrue();
     });
 
     it('does not throw on codes Intl cannot handle', () => {
       const key = buildLanguageSearchKey('not a code!', 'Mystery', 'en');
-      expect(languageMatchesSearch(key, 'mystery')).toBeTrue();
-    });
-  });
-
-  describe('languageMatchesSearch', () => {
-    const key = buildLanguageSearchKey('de', 'German', 'en');
-
-    it('matches everything when the query is empty or whitespace', () => {
-      expect(languageMatchesSearch(key, '')).toBeTrue();
-      expect(languageMatchesSearch(key, '   ')).toBeTrue();
-    });
-
-    it('is case-insensitive', () => {
-      expect(languageMatchesSearch(key, 'GERMAN')).toBeTrue();
-    });
-
-    it('rejects non-matching queries', () => {
-      expect(languageMatchesSearch(key, 'swahili')).toBeFalse();
+      expect(matches(key, 'mystery')).toBeTrue();
     });
   });
 
   describe('filterLanguages', () => {
     const languages = [
-      { name: 'Spanish', searchKey: buildLanguageSearchKey('es', 'Spanish') },
-      { name: 'German', searchKey: buildLanguageSearchKey('de', 'German') }
+      {
+        name: 'Spanish',
+        searchKey: buildLanguageSearchKey('es', 'Spanish', 'en')
+      },
+      {
+        name: 'German',
+        searchKey: buildLanguageSearchKey('de', 'German', 'en')
+      }
     ];
 
     it('returns the full list when the query is empty or whitespace', () => {
@@ -87,12 +82,18 @@ describe('language-search', () => {
       ).toEqual(languages);
     });
 
-    it('keeps only matching languages', () => {
+    it('is case- and diacritic-insensitive', () => {
       expect(
         filterLanguages(languages, (lang) => lang.searchKey, 'ESPAÑOL').map(
           (lang) => lang.name
         )
       ).toEqual(['Spanish']);
+    });
+
+    it('drops languages that do not match', () => {
+      expect(
+        filterLanguages(languages, (lang) => lang.searchKey, 'swahili')
+      ).toEqual([]);
     });
   });
 });

--- a/src/app/shared/language-search.ts
+++ b/src/app/shared/language-search.ts
@@ -50,3 +50,17 @@ export function languageMatchesSearch(
   const normalizedQuery = normalizeLanguageText(query);
   return !normalizedQuery || searchKey.includes(normalizedQuery);
 }
+
+// Like filtering with languageMatchesSearch, but normalizes the query once for
+// the whole list instead of once per language.
+export function filterLanguages<T>(
+  items: T[],
+  getSearchKey: (item: T) => string,
+  query: string
+): T[] {
+  const normalizedQuery = normalizeLanguageText(query);
+  if (!normalizedQuery) {
+    return items;
+  }
+  return items.filter((item) => getSearchKey(item).includes(normalizedQuery));
+}

--- a/src/app/shared/language-search.ts
+++ b/src/app/shared/language-search.ts
@@ -1,0 +1,52 @@
+/**
+ * Helpers for the language selector search inputs. A language's search key
+ * combines the name reported by the API with names derived from
+ * Intl.DisplayNames (the language's own name for itself and its name in the
+ * currently displayed language), so a match works no matter which language the
+ * user types in.
+ */
+
+export function normalizeLanguageText(text: string): string {
+  return (text || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim();
+}
+
+function getIntlLanguageName(
+  code: string,
+  displayLocale: string
+): string | null {
+  // Intl.DisplayNames throws on malformed locale codes, and the API includes
+  // codes Intl has no data for — treat both as "no extra name".
+  try {
+    const displayNames = new Intl.DisplayNames([displayLocale], {
+      type: 'language',
+      fallback: 'none'
+    });
+    return displayNames.of(code) || null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildLanguageSearchKey(
+  code: string,
+  name: string,
+  displayLocale?: string
+): string {
+  const names = [name, code, getIntlLanguageName(code, code)];
+  if (displayLocale) {
+    names.push(getIntlLanguageName(code, displayLocale));
+  }
+  return names.filter(Boolean).map(normalizeLanguageText).join('\n');
+}
+
+export function languageMatchesSearch(
+  searchKey: string,
+  query: string
+): boolean {
+  const normalizedQuery = normalizeLanguageText(query);
+  return !normalizedQuery || searchKey.includes(normalizedQuery);
+}

--- a/src/app/shared/language-search.ts
+++ b/src/app/shared/language-search.ts
@@ -34,7 +34,7 @@ function getIntlLanguageName(
 export function buildLanguageSearchKey(
   code: string,
   name: string,
-  displayLocale?: string
+  displayLocale: string
 ): string {
   const names = [name, code, getIntlLanguageName(code, code)];
   if (displayLocale) {
@@ -43,16 +43,7 @@ export function buildLanguageSearchKey(
   return names.filter(Boolean).map(normalizeLanguageText).join('\n');
 }
 
-export function languageMatchesSearch(
-  searchKey: string,
-  query: string
-): boolean {
-  const normalizedQuery = normalizeLanguageText(query);
-  return !normalizedQuery || searchKey.includes(normalizedQuery);
-}
-
-// Like filtering with languageMatchesSearch, but normalizes the query once for
-// the whole list instead of once per language.
+// Normalizes the query once for the whole list instead of once per language.
 export function filterLanguages<T>(
   items: T[],
   getSearchKey: (item: T) => string,

--- a/src/assets/locales/en/translation.json
+++ b/src/assets/locales/en/translation.json
@@ -1,7 +1,9 @@
 {
   "©1994-{{ year }} Cru. All Rights Reserved.": "©1994-{{ year }} Cru. All Rights Reserved.",
   "Lessons": "Lessons",
+  "No languages found": "No languages found",
   "Privacy Policy": "Privacy Policy",
+  "Search languages": "Search languages",
   "Terms of Use": "Terms of Use",
   "Tools": "Tools",
   "View All": "View All"


### PR DESCRIPTION
## Description

Related Jira ticket: [GT-2823](https://jira.cru.org/browse/GT-2823)

- Adds a search input to both navbar language selectors: the dashboard language modal and the tool-page header dropdown.
- Adds a shared helper (`src/app/shared/language-search.ts`) that builds a search key per language from the API display name, the language code, and `Intl.DisplayNames`-derived names: the language's own name for itself (e.g. "Deutsch", "español") and its name localized to the currently displayed language (e.g. "ingles" finds English while browsing in Spanish). This makes search work across languages regardless of how the list is displayed, per the ticket's note about displayed language text varying.
- Matching is case- and diacritic-insensitive ("francais" matches "Français"); language codes `Intl` has no data for fall back gracefully to name + code matching.
- Shows a "No languages found" empty state; the query is cleared each time a selector is opened. Search inputs use `dir="auto"` so RTL queries render correctly.
- Adds two i18n keys (`Search languages`, `No languages found`) to `src/assets/locales/en/translation.json`.
- Unit tests added for the helper and for filtering/reset behavior in both components (197 specs passing).

No dependent PRs.

## Testing

- Run `yarn start:dev` and go to `http://localhost:4200/en`
- Click the language name in the top-right of the navbar to open the language modal
- Type "espanol" — check that only "Spanish" remains; type "francais" — check the French variants remain; type gibberish — check the "No languages found" message appears
- Clear the search and open a tool (e.g. go to `/en/tool/v1/90minutes/0`), then click the language selector in the tool header
- Repeat the searches above in the dropdown (this tool has fewer languages, so e.g. "deutsch" correctly shows no results); try "العربية" — check "Arabic" matches
- Click a filtered language (e.g. Spanish) — check the tool reloads in that language; then search "ingles" — check "English" matches while the UI language is Spanish
- Close and reopen either selector — check the previous query is cleared

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [x] I have run `/agent-review` and addressed its findings before requesting a dev review
- [ ] I have requested a review from another person on the project
- [ ] I have tested my changes on staging or development
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

