### PR TITLE
[GT-3057] Support outlined buttons

### DIFF
--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -101,13 +101,15 @@ export const createEventId = (name: string, namespace?: string): EventId => {
   return new org.cru.godtools.shared.tool.parser.model.EventId(namespace, name);
 };
 
-const createButton = (text: string, url: string, event: string): Button => {
+const createButton = (
+  text: string,
+  url: string,
+  event: string,
+  style: Button['style']['name'] = 'CONTAINED'
+): Button => {
   return {
     url: url || null,
-    style: {
-      name: 'CONTAINED',
-      ordinal: 1
-    },
+    style: org.cru.godtools.shared.tool.parser.model.Button.Style[style],
     gravity: {
       name: 'CENTER',
       ordinal: 1
@@ -138,9 +140,10 @@ export const mockCallToAction = (text: string): CallToAction => {
 export const mockButton = (
   text: string,
   url: string,
-  event: string
+  event: string,
+  style: Button['style']['name'] = 'CONTAINED'
 ): Button => {
-  return createButton(text, url, event);
+  return createButton(text, url, event, style);
 };
 
 export const mockImage = (

--- a/src/app/page/component/content-button/content-button.component.html
+++ b/src/app/page/component/content-button/content-button.component.html
@@ -7,6 +7,7 @@
   <a
     *ngIf="button.url; else buttonTemplate"
     class="button"
+    [class.button-outline]="isOutlined"
     [href]="button.url"
     [ngStyle]="{
       'background-color': buttonBgColor,
@@ -21,6 +22,7 @@
     <button
       type="button"
       class="button"
+      [class.button-outline]="isOutlined"
       [ngStyle]="{
         'background-color': buttonBgColor,
         color: buttonTextColor

--- a/src/app/page/component/content-button/content-button.component.spec.ts
+++ b/src/app/page/component/content-button/content-button.component.spec.ts
@@ -17,6 +17,18 @@ describe('ContentButtonComponent', () => {
     buttonUrl,
     buttonEvent
   );
+  const mockOutlinedButton = mockButton(
+    buttonText,
+    '',
+    buttonEvent,
+    'OUTLINED'
+  );
+  const mockOutlinedUrlButton = mockButton(
+    buttonText,
+    buttonUrl,
+    '',
+    'OUTLINED'
+  );
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -99,5 +111,43 @@ describe('ContentButtonComponent', () => {
 
     component.onClick();
     expect(pageService.formAction).toHaveBeenCalledWith(buttonEvent);
+  });
+
+  it('adds outlined class when button style is OUTLINED (event button)', () => {
+    component.item = mockOutlinedButton;
+    component.ngOnChanges({
+      item: new SimpleChange(null, mockOutlinedButton, true)
+    });
+    fixture.detectChanges();
+
+    expect(component.isOutlined).toBe(true);
+    const button: HTMLButtonElement =
+      fixture.nativeElement.querySelector('button');
+    expect(button.classList).toContain('button-outline');
+  });
+
+  it('adds outlined class when button style is OUTLINED (url button)', () => {
+    component.item = mockOutlinedUrlButton;
+    component.ngOnChanges({
+      item: new SimpleChange(null, mockOutlinedUrlButton, true)
+    });
+    fixture.detectChanges();
+
+    expect(component.isOutlined).toBe(true);
+    const anchor: HTMLAnchorElement = fixture.nativeElement.querySelector('a');
+    expect(anchor.classList).toContain('button-outline');
+  });
+
+  it('omits outlined class for a contained (default) button', () => {
+    component.item = mockEventButton;
+    component.ngOnChanges({
+      item: new SimpleChange(null, mockEventButton, true)
+    });
+    fixture.detectChanges();
+
+    expect(component.isOutlined).toBe(false);
+    const button: HTMLButtonElement =
+      fixture.nativeElement.querySelector('button');
+    expect(button.classList).not.toContain('button-outline');
   });
 });

--- a/src/app/page/component/content-button/content-button.component.ts
+++ b/src/app/page/component/content-button/content-button.component.ts
@@ -27,6 +27,7 @@ export class ContentButtonComponent implements OnChanges, OnDestroy {
   buttonText: string;
   buttonTextColor: string;
   buttonBgColor: string;
+  isOutlined: boolean;
   dir$: Observable<string>;
   visibility: VisibilityWatchers;
 
@@ -54,6 +55,7 @@ export class ContentButtonComponent implements OnChanges, OnDestroy {
               this.button = this.item;
               this.buttonTextColor = '';
               this.buttonBgColor = '';
+              this.isOutlined = false;
               this.init();
             }
           }
@@ -68,6 +70,8 @@ export class ContentButtonComponent implements OnChanges, OnDestroy {
 
   private init(): void {
     this.visibility.init(this.button);
+
+    this.isOutlined = this.button.style?.name === 'OUTLINED';
 
     // TODO Allow Button styles when Books are ready
     // this.buttonTextColor = this.button.buttonColor || ''

--- a/src/app/page/component/page-navigation/page-navigation.component.html
+++ b/src/app/page/component/page-navigation/page-navigation.component.html
@@ -7,7 +7,7 @@
     <ng-container *ngIf="(isFirstPage$ | async) === false">
       <button
         (click)="previous()"
-        class="button button-white far fa-arrow-left"
+        class="button button-outline far fa-arrow-left"
       >
         <span class="hide"></span>
       </button>
@@ -30,7 +30,7 @@
     <ng-container *ngIf="(isFirstPage$ | async) === false">
       <button
         (click)="previous()"
-        class="button button-white far fa-arrow-right"
+        class="button button-outline far fa-arrow-right"
       >
         <span class="hide"></span>
       </button>

--- a/src/app/page/component/page/cyoa-card-collection-page/cyoa-card-collection-page.component.html
+++ b/src/app/page/component/page/cyoa-card-collection-page/cyoa-card-collection-page.component.html
@@ -41,7 +41,7 @@
         <ng-container *ngIf="!isFirstCard()">
           <button
             (click)="showPreviousCard()"
-            class="button button-white far fa-arrow-left"
+            class="button button-outline far fa-arrow-left"
           >
             <span class="hide"></span>
           </button>
@@ -68,7 +68,7 @@
           <a
             (click)="showPreviousCard()"
             href="javascript:void(0)"
-            class="button button-white far fa-arrow-right"
+            class="button button-outline far fa-arrow-right"
             ><span class="hide"></span
           ></a>
         </ng-container>

--- a/src/app/page/component/page/default-page.css
+++ b/src/app/page/component/page/default-page.css
@@ -11,9 +11,9 @@
   padding-left: 15px;
   padding-right: 15px;
 }
-.button.button-white {
+.button.button-outline {
   color: var(--kg-blue);
-  background-color: var(--kg-white);
+  background-color: transparent;
 }
 .button:hover {
   color: var(--kg-white) !important;


### PR DESCRIPTION
## Description

Add support for outlined buttons.

Jira ticket: https://jira.cru.org/browse/GT-3057

Before:

<img width="788" height="319" alt="Screenshot 2026-07-24 at 1 37 34 PM" src="https://github.com/user-attachments/assets/7e9bb883-450c-4327-b400-f468fc8a08f2" />

After:

<img width="780" height="328" alt="Screenshot 2026-07-24 at 1 37 25 PM" src="https://github.com/user-attachments/assets/b7f22d73-d3cd-4806-8f3d-5cbf1b4a94e3" />

## Testing

- Go to `/en/tool/v1/emojitool2/10` in dev
- Check that the Learn More button is rendered as an outlined button

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [x] I have run `/agent-review` and addressed its findings before requesting a dev review
- [ ] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from a randomly-chosen team member
- [ ] I have tested my changes on staging or development
- [ ] I have cleaned up my commit history
