### PR TITLE
[no-Jira] Upgrade to node.js v24 workflows

### DIFF
--- a/.github/workflows/ai-review-auto-approve.yml
+++ b/.github/workflows/ai-review-auto-approve.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       head_branch:
-        description: "The PR head branch name"
+        description: 'The PR head branch name'
         required: true
         type: string
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check agent review and auto-approve
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           HEAD_BRANCH: ${{ inputs.head_branch }}
         with:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,8 +16,8 @@ jobs:
   download:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -30,7 +30,7 @@ jobs:
         env:
           CROWDIN_API_TOKEN: ${{ secrets.CROWDIN_API_TOKEN }}
       - name: 🔀 Create PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         env:
           # Disable git hooks because we are only modifying translation files
           HUSKY: 0

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Node.js setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
 
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Node.js setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
 
@@ -62,10 +62,10 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Node.js setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
 
@@ -79,8 +79,8 @@ jobs:
     name: 🌐 Translations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
       - name: 📦 Install Dependencies
@@ -113,10 +113,10 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Node.js setup
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: .tool-versions
 
@@ -141,7 +141,7 @@ jobs:
           appDomain: https://${{ secrets.HOST_NAME }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_IAM_ROLE_ARN }}

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event.label.name == 'Review' && github.event.pull_request.draft == false
     steps:
       - name: Request review from a random web-engineering-js member
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           # Listing team members requires org read access, which the default
           # GITHUB_TOKEN does not have. Without a REVIEW_BOT_TOKEN secret

--- a/.github/workflows/update-staging.yml
+++ b/.github/workflows/update-staging.yml
@@ -2,7 +2,7 @@ name: Pipeline
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [labeled, synchronize]
 
@@ -10,7 +10,7 @@ jobs:
   update-staging:
     name: 🌱 Merge to Staging
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'On Staging')
+    if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'On Staging')
     steps:
       - uses: actions/checkout@v7
       - name: 🖇️ Merge current branch into staging
@@ -23,7 +23,7 @@ jobs:
   update-development:
     name: 🛠 Merge to Development
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'On Staging') || contains(github.event.pull_request.labels.*.name, 'On Development')
+    if: github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'On Staging') || contains(github.event.pull_request.labels.*.name, 'On Development')
     steps:
       - uses: actions/checkout@v7
       - name: 🖇️ Merge current branch into development

--- a/.github/workflows/update-staging.yml
+++ b/.github/workflows/update-staging.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'On Staging')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 🖇️ Merge current branch into staging
         uses: devmasx/merge-branch@1.4.0
         with:
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'On Staging') || contains(github.event.pull_request.labels.*.name, 'On Development')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 🖇️ Merge current branch into development
         uses: devmasx/merge-branch@1.4.0
         with:


### PR DESCRIPTION
## Description

Upgrade all possible workflows to a version that runs on node 24.

Also fix `update-staging.yml` to reference `main` instead of `master.

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [x] I have run `/agent-review` and addressed its findings before requesting a dev review
- [ ] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from a randomly-chosen team member
- [ ] I have tested my changes on staging or development
- [ ] I have cleaned up my commit history
