### PR TITLE
GT-3059 Load tool content images from published files instead of attachments

### DIFF
--- a/src/app/_tests/mocks.ts
+++ b/src/app/_tests/mocks.ts
@@ -28,7 +28,7 @@ import {
   Video
 } from 'src/app/services/xml-parser-service/xml-parser.service';
 
-const createResource = (name: string, localName: string): Resource => {
+export const createResource = (name: string, localName: string): Resource => {
   return {
     localName,
     name,

--- a/src/app/page/component/content-animation/content-animation.component.spec.ts
+++ b/src/app/page/component/content-animation/content-animation.component.spec.ts
@@ -1,5 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { APIURL } from 'src/app/api/url';
 import { mockAnimation } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
 import { ContentAnimationComponent } from './content-animation.component';
@@ -12,13 +13,7 @@ describe('ContentAnimationComponent', () => {
   const animation = mockAnimation(fileName, filePath, 'event');
   const animationWithUrl = mockAnimation(fileName, filePath, null);
   const animationWithEvents = mockAnimation(fileName, null, 'event');
-  const fileNameNotAdded = 'name-of-file-not-added.png';
-  const filePathNotAdded = `/some-folder/${fileName}`;
-  const animationNoNameNotAdded = mockAnimation(
-    fileNameNotAdded,
-    filePathNotAdded,
-    'event'
-  );
+  const animationNoPublishedFile = mockAnimation(fileName, null, 'event');
   let pageService: PageService;
 
   beforeEach(waitForAsync(() => {
@@ -31,30 +26,30 @@ describe('ContentAnimationComponent', () => {
     fixture = TestBed.createComponent(ContentAnimationComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    pageService.addToAnimationsDict(fileName, filePath);
-    spyOn(pageService, 'findAttachment');
   }));
 
-  it('Fetch animation from pageService', async () => {
+  it('resolves the animation from the published content location', () => {
     component.item = animation;
     component.ngOnChanges({
       item: new SimpleChange(null, animation, true)
     });
-    expect(pageService.findAttachment).not.toHaveBeenCalledWith(fileName);
-    expect(component.anmResource).toEqual(filePath);
+    expect(component.anmResource).toEqual(
+      APIURL.GET_TRANSLATION_FILES + filePath
+    );
     expect(component.lottieOptions).toEqual({
-      path: filePath,
+      path: APIURL.GET_TRANSLATION_FILES + filePath,
       loop: true,
       autoplay: true
     });
   });
 
-  it('Find animation from pageService if not in pageService', () => {
-    component.item = animationNoNameNotAdded;
+  it('does not build lottie options when the resource has no published file', () => {
+    component.item = animationNoPublishedFile;
     component.ngOnChanges({
-      item: new SimpleChange(null, animationNoNameNotAdded, true)
+      item: new SimpleChange(null, animationNoPublishedFile, true)
     });
-    expect(pageService.findAttachment).toHaveBeenCalledWith(fileNameNotAdded);
+    expect(component.anmResource).toBeNull();
+    expect(component.lottieOptions).toBeUndefined();
   });
 
   it('fires events only when clicked on with events', () => {

--- a/src/app/page/component/content-animation/content-animation.component.ts
+++ b/src/app/page/component/content-animation/content-animation.component.ts
@@ -97,9 +97,7 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
     if (!this.animation?.resource) {
       return;
     }
-    this.anmResource = this.pageService.resolveResourceUrl(
-      this.animation.resource
-    );
+    this.anmResource = this.pageService.getImageUrl(this.animation.resource);
 
     if (this.anmResource) {
       this.lottieOptions = {

--- a/src/app/page/component/content-animation/content-animation.component.ts
+++ b/src/app/page/component/content-animation/content-animation.component.ts
@@ -94,20 +94,12 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
   private init(): void {
     this.visibility.init(this.item);
 
-    if (!this.animation?.resource?.name) {
+    if (!this.animation?.resource) {
       return;
     }
-    this.anmResource = this.pageService.getAnimationUrl(
-      this.animation.resource.name
+    this.anmResource = this.pageService.resolveResourceUrl(
+      this.animation.resource
     );
-    if (
-      this.anmResource === this.animation.resource.name &&
-      !this.anmResource.includes('http')
-    ) {
-      this.anmResource = this.pageService.findAttachment(
-        this.animation.resource.name
-      );
-    }
 
     if (this.anmResource) {
       this.lottieOptions = {

--- a/src/app/page/component/content-animation/content-animation.component.ts
+++ b/src/app/page/component/content-animation/content-animation.component.ts
@@ -97,7 +97,7 @@ export class ContentAnimationComponent implements OnChanges, OnDestroy {
     if (!this.animation?.resource) {
       return;
     }
-    this.anmResource = this.pageService.getImageUrl(this.animation.resource);
+    this.anmResource = this.pageService.getResourceUrl(this.animation.resource);
 
     if (this.anmResource) {
       this.lottieOptions = {

--- a/src/app/page/component/content-button/content-button.component.spec.ts
+++ b/src/app/page/component/content-button/content-button.component.spec.ts
@@ -1,5 +1,6 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { APIURL } from 'src/app/api/url';
 import { Button } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { createResource, mockButton, mockText } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
@@ -117,9 +118,6 @@ describe('ContentButtonComponent', () => {
   it('does not render start/end images from the child text node', () => {
     // Per the content schema, start-image/end-image only exist on standalone
     // text elements; buttons render images via icon/icon-gravity only.
-    const pageService = TestBed.inject(PageService);
-    pageService.addToImagesDict('image.png', 'https://cru.org/img.png');
-
     const buttonWithTextImages = {
       ...mockButton(buttonText, '', buttonEvent),
       text: mockText(buttonText)
@@ -134,9 +132,6 @@ describe('ContentButtonComponent', () => {
   });
 
   it('renders the icon inside the anchor variant', () => {
-    const pageService = TestBed.inject(PageService);
-    pageService.addToImagesDict('icon.png', 'https://cru.org/icon.png');
-
     const urlButtonWithIcon = {
       ...mockButton(buttonText, buttonUrl, ''),
       icon: createResource('icon.png', 'icon.png'),
@@ -154,9 +149,6 @@ describe('ContentButtonComponent', () => {
   });
 
   it('renders the button icon before the text when icon-gravity is start', () => {
-    const pageService = TestBed.inject(PageService);
-    pageService.addToImagesDict('icon.png', 'https://cru.org/icon.png');
-
     const iconButton = {
       ...mockButton(buttonText, '', buttonEvent),
       icon: createResource('icon.png', 'icon.png'),
@@ -173,7 +165,9 @@ describe('ContentButtonComponent', () => {
       fixture.nativeElement.querySelector('button');
     const icon: HTMLImageElement = button.querySelector('img');
     expect(icon).toBeTruthy();
-    expect(icon.getAttribute('src')).toBe('https://cru.org/icon.png');
+    expect(icon.getAttribute('src')).toBe(
+      APIURL.GET_TRANSLATION_FILES + 'icon.png'
+    );
     expect(icon.style.width).toBe('18px');
     expect(icon.classList).toContain('buttonImgStart');
     expect(icon.getAttribute('alt')).toBe('');
@@ -181,9 +175,6 @@ describe('ContentButtonComponent', () => {
   });
 
   it('renders the button icon after the text when icon-gravity is end', () => {
-    const pageService = TestBed.inject(PageService);
-    pageService.addToImagesDict('icon.png', 'https://cru.org/icon.png');
-
     const iconButton = {
       ...mockButton(buttonText, '', buttonEvent),
       icon: createResource('icon.png', 'icon.png'),
@@ -203,9 +194,6 @@ describe('ContentButtonComponent', () => {
   });
 
   it('does not render the icon when gravity is CENTER', () => {
-    const pageService = TestBed.inject(PageService);
-    pageService.addToImagesDict('icon.png', 'https://cru.org/icon.png');
-
     const iconButton = {
       ...mockButton(buttonText, '', buttonEvent),
       icon: createResource('icon.png', 'icon.png'),
@@ -231,15 +219,10 @@ describe('ContentButtonComponent', () => {
     expect(fixture.nativeElement.querySelectorAll('button img').length).toBe(0);
   });
 
-  it('does not resolve the icon from the attachments table', () => {
-    // The attachments table also contains unpublished files; icons only
-    // resolve through the images dict built from the published manifest.
-    const pageService = TestBed.inject(PageService);
-    pageService.addAttachment('icon.png', 'https://cru.org/attachment.png');
-
+  it('does not render the icon when it has no published file', () => {
     const iconButton = {
       ...mockButton(buttonText, '', buttonEvent),
-      icon: createResource('icon.png', 'icon.png'),
+      icon: createResource('icon.png', null),
       iconGravity: { name: 'START', ordinal: 0 },
       iconSize: 18
     } as Button;
@@ -253,9 +236,6 @@ describe('ContentButtonComponent', () => {
   });
 
   it('gives the icon a non-empty alt when the button has no text label', () => {
-    const pageService = TestBed.inject(PageService);
-    pageService.addToImagesDict('icon.png', 'https://cru.org/icon.png');
-
     const iconOnlyButton = {
       ...mockButton('', '', buttonEvent),
       text: mockText(''),

--- a/src/app/page/component/content-button/content-button.component.ts
+++ b/src/app/page/component/content-button/content-button.component.ts
@@ -8,7 +8,6 @@ import {
 import { Observable } from 'rxjs';
 import {
   Button,
-  Resource,
   Text
 } from 'src/app/services/xml-parser-service/xml-parser.service';
 import { PageService } from '../../service/page-service.service';
@@ -90,7 +89,7 @@ export class ContentButtonComponent implements OnChanges, OnDestroy {
       this.buttonText = this.text?.text || '';
     }
 
-    this.iconResource = this.resolveImage(this.button.icon);
+    this.iconResource = this.pageService.getResourceUrl(this.button.icon);
     this.iconWidth = this.button.iconSize ? this.button.iconSize + 'px' : null;
     this.iconGravity = this.button.iconGravity?.name || '';
 
@@ -105,16 +104,5 @@ export class ContentButtonComponent implements OnChanges, OnDestroy {
   private imageAltFallback(): string {
     const name = this.button.icon?.name || '';
     return name.replace(/\.[^.]+$/, '') || 'button';
-  }
-
-  private resolveImage(resource: Resource | null): string | null {
-    if (!resource?.name) {
-      return null;
-    }
-    // Only resolve through the images dict, which is limited to resources in
-    // the published manifest; the attachments table also contains unpublished
-    // files. getImageUrl echoes the name back when the image is not found.
-    const url = this.pageService.getImageUrl(resource.name);
-    return url && url !== resource.name ? url : null;
   }
 }

--- a/src/app/page/component/content-image/content-image.component.spec.ts
+++ b/src/app/page/component/content-image/content-image.component.spec.ts
@@ -1,5 +1,6 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { APIURL } from 'src/app/api/url';
 import { mockImage } from '../../../_tests/mocks';
 import { PageService } from '../../service/page-service.service';
 import { ContentImageComponent } from './content-image.component';
@@ -14,9 +15,6 @@ describe('ContentImageComponent', () => {
   const imageOnlyUrl = mockImage(fileName, filePath, null);
   const imageWithEventsAndUrl = mockImage(fileName, filePath, imageEvent);
   const imageNotClickable = mockImage(fileName, null, null);
-  const fileNameNotAdded = 'name-of-file-not-added.png';
-  const filePathNotAdded = `/some-folder/${fileName}`;
-  const imageNoNameNotAdded = mockImage(fileNameNotAdded, filePathNotAdded);
   let pageService: PageService;
 
   beforeEach(waitForAsync(() => {
@@ -28,25 +26,22 @@ describe('ContentImageComponent', () => {
     fixture = TestBed.createComponent(ContentImageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    pageService.addToImagesDict(fileName, filePath);
-    spyOn(pageService, 'findAttachment');
   }));
 
-  it('Fetch image from pageService', async () => {
+  it('resolves the image from the published content location', () => {
     component.item = imageWithEventsAndUrl;
     component.ngOnChanges({
       item: new SimpleChange(null, imageWithEventsAndUrl, true)
     });
-    expect(pageService.findAttachment).not.toHaveBeenCalledWith(fileName);
-    expect(component.imgResource).toBe(filePath);
+    expect(component.imgResource).toBe(APIURL.GET_TRANSLATION_FILES + filePath);
   });
 
-  it('Find image from pageService if not in pageService', () => {
-    component.item = imageNoNameNotAdded;
+  it('renders no image when the resource has no published file', () => {
+    component.item = imageNotClickable;
     component.ngOnChanges({
-      item: new SimpleChange(null, imageNoNameNotAdded, true)
+      item: new SimpleChange(null, imageNotClickable, true)
     });
-    expect(pageService.findAttachment).toHaveBeenCalledWith(fileNameNotAdded);
+    expect(component.imgResource).toBe('');
   });
 
   it('fires events only when clicked on with events', () => {

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -68,7 +68,8 @@ export class ContentImageComponent implements OnChanges, OnDestroy {
   private init(): void {
     this.visibility.init(this.image);
 
-    this.imgResource = this.pageService.getImageUrl(this.image.resource) || '';
+    this.imgResource =
+      this.pageService.getResourceUrl(this.image.resource) || '';
     const dimensions = DimensionParser(this.image.width);
     this.width = dimensions?.value
       ? dimensions.value + dimensions.symbol

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -68,17 +68,8 @@ export class ContentImageComponent implements OnChanges, OnDestroy {
   private init(): void {
     this.visibility.init(this.image);
 
-    this.imgResource = this.pageService.getImageUrl(
-      this.image.resource.name || ''
-    );
-    // Try to find image in all attachments
-    if (
-      this.imgResource === this.image.resource.name &&
-      !this.imgResource.includes('http')
-    ) {
-      this.imgResource =
-        this.pageService.findAttachment(this.image.resource.name) || '';
-    }
+    this.imgResource =
+      this.pageService.resolveResourceUrl(this.image.resource) || '';
     const dimensions = DimensionParser(this.image.width);
     this.width = dimensions?.value
       ? dimensions.value + dimensions.symbol

--- a/src/app/page/component/content-image/content-image.component.ts
+++ b/src/app/page/component/content-image/content-image.component.ts
@@ -68,8 +68,7 @@ export class ContentImageComponent implements OnChanges, OnDestroy {
   private init(): void {
     this.visibility.init(this.image);
 
-    this.imgResource =
-      this.pageService.resolveResourceUrl(this.image.resource) || '';
+    this.imgResource = this.pageService.getImageUrl(this.image.resource) || '';
     const dimensions = DimensionParser(this.image.width);
     this.width = dimensions?.value
       ? dimensions.value + dimensions.symbol

--- a/src/app/page/component/content-text/content-text.component.ts
+++ b/src/app/page/component/content-text/content-text.component.ts
@@ -87,17 +87,9 @@ export class ContentTextComponent implements OnChanges, OnDestroy {
       // color: this.text.textColor || ''
     };
 
-    this.startImgResource = this.item.startImage
-      ? this.pageService.getImageUrl(this.item.startImage.name || '')
-      : null;
-    // Try to find image in all attachments
-    if (
-      this.startImgResource === this.item.startImage?.name &&
-      !this.startImgResource.includes('http')
-    ) {
-      this.startImgResource =
-        this.pageService.findAttachment(this.item.startImage?.name) || '';
-    }
+    this.startImgResource = this.pageService.resolveResourceUrl(
+      this.item.startImage
+    );
     this.startImgWidth = this.item.startImageSize
       ? this.item.startImageSize + 'px'
       : null;

--- a/src/app/page/component/content-text/content-text.component.ts
+++ b/src/app/page/component/content-text/content-text.component.ts
@@ -87,7 +87,9 @@ export class ContentTextComponent implements OnChanges, OnDestroy {
       // color: this.text.textColor || ''
     };
 
-    this.startImgResource = this.pageService.getImageUrl(this.item.startImage);
+    this.startImgResource = this.pageService.getResourceUrl(
+      this.item.startImage
+    );
     this.startImgWidth = this.item.startImageSize
       ? this.item.startImageSize + 'px'
       : null;

--- a/src/app/page/component/content-text/content-text.component.ts
+++ b/src/app/page/component/content-text/content-text.component.ts
@@ -87,9 +87,7 @@ export class ContentTextComponent implements OnChanges, OnDestroy {
       // color: this.text.textColor || ''
     };
 
-    this.startImgResource = this.pageService.resolveResourceUrl(
-      this.item.startImage
-    );
+    this.startImgResource = this.pageService.getImageUrl(this.item.startImage);
     this.startImgWidth = this.item.startImageSize
       ? this.item.startImageSize + 'px'
       : null;

--- a/src/app/page/page.component.spec.ts
+++ b/src/app/page/page.component.spec.ts
@@ -10,6 +10,7 @@ import {
   mockPageComponent,
   mockTractPage
 } from '../_tests/mocks';
+import { APIURL } from '../api/url';
 import { CommonService } from '../services/common.service';
 import { LoaderService } from '../services/loader-service/loader.service';
 import {
@@ -19,7 +20,7 @@ import {
   XmlParserData,
   godToolsParser
 } from '../services/xml-parser-service/xml-parser.service';
-import { PageComponent, getResourceTypeEnum } from './page.component';
+import { PageComponent } from './page.component';
 import { PageService } from './service/page-service.service';
 
 describe('PageComponent', () => {
@@ -267,31 +268,6 @@ describe('PageComponent', () => {
     expect(router.navigate).toHaveBeenCalledTimes(0);
   });
 
-  describe('getResource()', () => {
-    const file2Name = 'file-name-2.png';
-    const file2Url = 'https://cru.org/assets/file-name-2.png';
-    it('should fetch an image', async () => {
-      await component.getResource(getResourceTypeEnum.image, file2Name);
-      expect(pageService.getAllImages()[file2Name]).toEqual(file2Url);
-    });
-
-    it('should fetch an animation', async () => {
-      const addToAnimationsDictSpy = spyOn(pageService, 'addToAnimationsDict');
-      const fileUrl = await component.getResource(
-        getResourceTypeEnum.animation,
-        file2Name
-      );
-      expect(addToAnimationsDictSpy).toHaveBeenCalledWith(file2Name, file2Url);
-      expect(fileUrl).toEqual(file2Url);
-    });
-
-    it('should not download resource', async () => {
-      spyOn(pageService, 'getAllImages');
-      await component.getResource(getResourceTypeEnum.image, 'file-name-3.png');
-      expect(pageService.getAllImages).toHaveBeenCalledTimes(0);
-    });
-  });
-
   describe('loadBookPage()', () => {
     it('does not call showPage', async () => {
       component.loadBookPage(tractPage);
@@ -360,7 +336,7 @@ describe('PageComponent', () => {
     });
   });
 
-  it('loadBookManifestXML() fetches only needed resources', async () => {
+  it('loadBookManifestXML() prefetches published image files', async () => {
     component._pageBookIndex = mockPageBookIndexData;
 
     component._selectedLanguage = { id: '2222' };
@@ -374,7 +350,8 @@ describe('PageComponent', () => {
 
     const fakeManifest = {
       relatedFiles: {
-        asJsReadonlySetView: () => new Set(['aaa111.png', 'bbb222.png'])
+        asJsReadonlySetView: () =>
+          new Set(['aaa111.png', 'bbb222.png', 'ccc333.json'])
       },
       pages: []
     };
@@ -382,26 +359,23 @@ describe('PageComponent', () => {
       Promise.resolve({ manifest: fakeManifest } as unknown as XmlParserData)
     );
 
-    const addAttachmentSpy = spyOn(pageService, 'addAttachment');
-    const getResourceSpy = spyOn(component, 'getResource');
-
     component['loadBookManifestXML']();
     await fixture.whenStable();
 
-    expect(addAttachmentSpy).toHaveBeenCalledTimes(3);
+    const prefetched = Array.from(
+      document.head.querySelectorAll('link[rel="prefetch"]')
+    ).map((link: HTMLLinkElement) => link.getAttribute('href'));
 
-    expect(getResourceSpy).toHaveBeenCalledWith(
-      getResourceTypeEnum.image,
-      'needed-1.png'
+    expect(prefetched).toContain(APIURL.GET_TRANSLATION_FILES + 'aaa111.png');
+    expect(prefetched).toContain(APIURL.GET_TRANSLATION_FILES + 'bbb222.png');
+    // Non-image files (page XML, animations) are not prefetched
+    expect(prefetched).not.toContain(
+      APIURL.GET_TRANSLATION_FILES + 'ccc333.json'
     );
-    expect(getResourceSpy).toHaveBeenCalledWith(
-      getResourceTypeEnum.image,
-      'needed-2.png'
-    );
-    expect(getResourceSpy).not.toHaveBeenCalledWith(
-      getResourceTypeEnum.image,
-      'skipped.png'
-    );
+
+    document.head
+      .querySelectorAll('link[rel="prefetch"]')
+      .forEach((link) => link.remove());
   });
 
   it('getAvailableLanguagesForSelectedBook() no languages downloaded', () => {

--- a/src/app/page/page.component.ts
+++ b/src/app/page/page.component.ts
@@ -87,11 +87,6 @@ interface JsonApiResponse {
   included: JsonApiResource[];
 }
 
-export enum getResourceTypeEnum {
-  animation = 'animation',
-  image = 'image'
-}
-
 @Component({
   selector: 'app-page',
   templateUrl: './page.component.html',
@@ -356,39 +351,13 @@ export class PageComponent implements OnInit, OnDestroy {
     );
   }
 
-  private getResource(
-    resourceType: getResourceTypeEnum,
-    resourceName: string
-  ): string {
-    if (!resourceName) {
-      return '';
-    }
-
-    if (this._pageBookIndex !== undefined && this._pageBookIndex !== null) {
-      const attachments = this._pageBookIndex.included.filter(
-        (row) =>
-          row.type.toLowerCase() === 'attachment' &&
-          (row.attributes['file-file-name'] as string).toLowerCase() ===
-            resourceName.toLowerCase()
-      );
-
-      if (!attachments.length) {
-        return '';
-      }
-
-      const fileUrl = attachments[0].attributes.file as string;
-      if (resourceType === getResourceTypeEnum.animation) {
-        this.pageService.addToAnimationsDict(resourceName, fileUrl);
-        return fileUrl;
-      } else if (resourceType === getResourceTypeEnum.image) {
-        const link = document.createElement('link');
-        link.href = fileUrl;
-        link.rel = 'prefetch';
-        document.getElementsByTagName('head')[0].appendChild(link);
-        this.pageService.addToImagesDict(resourceName, fileUrl);
-        return fileUrl;
-      }
-    }
+  // Prefetch a file from the published content location so it is cached
+  // before the pages that reference it render.
+  private prefetchPublishedFile(fileName: string): void {
+    const link = document.createElement('link');
+    link.href = APIURL.GET_TRANSLATION_FILES + fileName;
+    link.rel = 'prefetch';
+    document.getElementsByTagName('head')[0].appendChild(link);
   }
 
   private loadBookPage(page: TractPage): void {
@@ -449,7 +418,6 @@ export class PageComponent implements OnInit, OnDestroy {
       const manifestName = item.attributes['manifest-name'] as string;
       this.pullParserFactory.setOrigin(APIURL.GET_TRANSLATION_FILES);
       const config = ParserConfig.createParserConfig()
-        .withLegacyWebImageResources(true)
         .withSupportedFeatures([
           ParserConfig.Companion.FEATURE_ANIMATION,
           ParserConfig.Companion.FEATURE_MULTISELECT,
@@ -465,38 +433,11 @@ export class PageComponent implements OnInit, OnDestroy {
           const { manifest } = data as XmlParserData;
           this._pageBookManifest = manifest;
 
-          // Remove file extensions to get the SHAs for manifest resources
-          const neededShas = new Set(
-            Array.from(manifest.relatedFiles?.asJsReadonlySetView() ?? []).map(
-              (file) => file.replace(/\.[^.]+$/, '')
-            )
-          );
-
-          // Loop through and get all needed resources.
-          this._pageBookIndex.included.forEach((resource) => {
-            const { attributes, type } = resource;
-
-            if (type !== 'attachment') {
-              return;
-            }
-
-            const fileName = attributes['file-file-name'] as string;
-            // Add all resources to the lookup table so they can be accessed by any page that needs them
-            this.pageService.addAttachment(fileName, attributes.file as string);
-
-            if (!neededShas.has(attributes.sha256 as string)) {
-              return;
-            }
-
-            const isImage = IMAGE_EXTENSIONS_REGEX.test(fileName);
-
-            this.getResource(
-              isImage
-                ? getResourceTypeEnum.image
-                : getResourceTypeEnum.animation,
-              fileName
-            );
-          });
+          // Images are published as immutable, sha256-named files alongside
+          // the page XML; prefetch them from the published content location.
+          Array.from(manifest.relatedFiles?.asJsReadonlySetView() ?? [])
+            .filter((file) => IMAGE_EXTENSIONS_REGEX.test(file))
+            .forEach((file) => this.prefetchPublishedFile(file));
 
           if (manifest?.pages?.length) {
             this._pageBookSubPagesManifest = manifest.pages;

--- a/src/app/page/service/page-service.service.spec.ts
+++ b/src/app/page/service/page-service.service.spec.ts
@@ -129,19 +129,17 @@ describe('PageService', () => {
     });
   });
 
-  describe('resolveResourceUrl()', () => {
+  describe('getImageUrl()', () => {
     it('builds the published files url from the sha-named localName', () => {
       const resource = createResource('image.png', 'abc123def456.png');
-      expect(service.resolveResourceUrl(resource)).toBe(
+      expect(service.getImageUrl(resource)).toBe(
         APIURL.GET_TRANSLATION_FILES + 'abc123def456.png'
       );
     });
 
     it('returns null when the resource has no published file', () => {
-      expect(service.resolveResourceUrl(null)).toBeNull();
-      expect(
-        service.resolveResourceUrl(createResource('image.png', null))
-      ).toBeNull();
+      expect(service.getImageUrl(null)).toBeNull();
+      expect(service.getImageUrl(createResource('image.png', null))).toBeNull();
     });
   });
 });

--- a/src/app/page/service/page-service.service.spec.ts
+++ b/src/app/page/service/page-service.service.spec.ts
@@ -129,17 +129,19 @@ describe('PageService', () => {
     });
   });
 
-  describe('getImageUrl()', () => {
+  describe('getResourceUrl()', () => {
     it('builds the published files url from the sha-named localName', () => {
       const resource = createResource('image.png', 'abc123def456.png');
-      expect(service.getImageUrl(resource)).toBe(
+      expect(service.getResourceUrl(resource)).toBe(
         APIURL.GET_TRANSLATION_FILES + 'abc123def456.png'
       );
     });
 
     it('returns null when the resource has no published file', () => {
-      expect(service.getImageUrl(null)).toBeNull();
-      expect(service.getImageUrl(createResource('image.png', null))).toBeNull();
+      expect(service.getResourceUrl(null)).toBeNull();
+      expect(
+        service.getResourceUrl(createResource('image.png', null))
+      ).toBeNull();
     });
   });
 });

--- a/src/app/page/service/page-service.service.spec.ts
+++ b/src/app/page/service/page-service.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed, inject } from '@angular/core/testing';
-import { createEventId } from 'src/app/_tests/mocks';
+import { createEventId, createResource } from 'src/app/_tests/mocks';
+import { APIURL } from 'src/app/api/url';
 import { PageService } from './page-service.service';
 
 describe('PageService', () => {
@@ -125,6 +126,22 @@ describe('PageService', () => {
       console.log('stack', stack);
       expect(stack).toEqual(['0', '1']);
       done();
+    });
+  });
+
+  describe('resolveResourceUrl()', () => {
+    it('builds the published files url from the sha-named localName', () => {
+      const resource = createResource('image.png', 'abc123def456.png');
+      expect(service.resolveResourceUrl(resource)).toBe(
+        APIURL.GET_TRANSLATION_FILES + 'abc123def456.png'
+      );
+    });
+
+    it('returns null when the resource has no published file', () => {
+      expect(service.resolveResourceUrl(null)).toBeNull();
+      expect(
+        service.resolveResourceUrl(createResource('image.png', null))
+      ).toBeNull();
     });
   });
 });

--- a/src/app/page/service/page-service.service.ts
+++ b/src/app/page/service/page-service.service.ts
@@ -64,7 +64,7 @@ export class PageService {
   // Resolve a manifest resource to its published, immutable file. Resources
   // are copied to the published content location under their sha256-based
   // filename (localName) when a tool is published.
-  getImageUrl(resource: Resource | null): string | null {
+  getResourceUrl(resource: Resource | null): string | null {
     return resource?.localName
       ? APIURL.GET_TRANSLATION_FILES + resource.localName
       : null;

--- a/src/app/page/service/page-service.service.ts
+++ b/src/app/page/service/page-service.service.ts
@@ -64,7 +64,7 @@ export class PageService {
   // Resolve a manifest resource to its published, immutable file. Resources
   // are copied to the published content location under their sha256-based
   // filename (localName) when a tool is published.
-  resolveResourceUrl(resource: Resource | null): string | null {
+  getImageUrl(resource: Resource | null): string | null {
     return resource?.localName
       ? APIURL.GET_TRANSLATION_FILES + resource.localName
       : null;

--- a/src/app/page/service/page-service.service.ts
+++ b/src/app/page/service/page-service.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { APIURL } from 'src/app/api/url';
 import { formatEvents } from 'src/app/shared/formatEvents';
 import {
   EventId,
   ParserState,
+  Resource,
   State
 } from '../../services/xml-parser-service/xml-parser.service';
 
@@ -31,9 +33,6 @@ export class PageService {
   private _isLastPage = new BehaviorSubject<boolean>(false);
   private _isForm = new BehaviorSubject<boolean>(false);
   private _isModal = new BehaviorSubject<boolean>(false);
-  private _imageUrlsDict = new BehaviorSubject<string[]>([]);
-  private _animationUrlsDict = new BehaviorSubject<string[]>([]);
-  private _allAttachmentResources = new Map<string, string>();
   private _navigationStack = new BehaviorSubject<string[]>([]);
   private XmlParserState = State.createState();
 
@@ -60,18 +59,15 @@ export class PageService {
     this._isLastPage.next(false);
     this._isForm.next(false);
     this._isModal.next(false);
-    this.clearImagesDict();
-    this.clearAnimationsDict();
   }
 
-  addAttachment(pImageName: string, pImageUrl: string): void {
-    const tImages = this._allAttachmentResources.get(pImageName);
-    if (!tImages) this._allAttachmentResources.set(pImageName, pImageUrl);
-  }
-
-  findAttachment(pImageName: string): string {
-    const tImages = this._allAttachmentResources.get(pImageName);
-    return tImages || '';
+  // Resolve a manifest resource to its published, immutable file. Resources
+  // are copied to the published content location under their sha256-based
+  // filename (localName) when a tool is published.
+  resolveResourceUrl(resource: Resource | null): string | null {
+    return resource?.localName
+      ? APIURL.GET_TRANSLATION_FILES + resource.localName
+      : null;
   }
 
   nextPage(): void {
@@ -142,45 +138,6 @@ export class PageService {
 
   hideTip(): void {
     this._visibleTip.next('');
-  }
-
-  clearImagesDict(): void {
-    this._imageUrlsDict.next([]);
-  }
-
-  addToImagesDict(pImageName: string, pImageUrl: string): void {
-    const tImages = this._imageUrlsDict.getValue();
-    tImages[pImageName.toLocaleLowerCase()] = pImageUrl;
-    this._imageUrlsDict.next(tImages);
-  }
-
-  getImageUrl(pImageName: string): string {
-    const tImages = this._imageUrlsDict.getValue();
-    if (tImages && tImages[pImageName.toLocaleLowerCase()]) {
-      return tImages[pImageName.toLocaleLowerCase()];
-    }
-    return pImageName;
-  }
-  getAllImages() {
-    return this._imageUrlsDict.getValue();
-  }
-
-  clearAnimationsDict(): void {
-    this._animationUrlsDict.next([]);
-  }
-
-  addToAnimationsDict(pFileName: string, pFileUrl: string): void {
-    const tFiles = this._animationUrlsDict.getValue();
-    tFiles[pFileName.toLocaleLowerCase()] = pFileUrl;
-    this._animationUrlsDict.next(tFiles);
-  }
-
-  getAnimationUrl(pFileName: string): string {
-    const tFiles = this._animationUrlsDict.getValue();
-    if (tFiles && tFiles[pFileName.toLocaleLowerCase()]) {
-      return tFiles[pFileName.toLocaleLowerCase()];
-    }
-    return pFileName;
   }
 
   isRestricted(deviceTypes: string[]): boolean {


### PR DESCRIPTION
## Description

- Resolves all rendered tool content resources (content images, text `start-image`s, and Lottie animations) directly to the immutable, sha256-named published files under `/translations/files/{resource.localName}`, instead of looking URLs up in dictionaries built from the **attachments table**. The attachments mechanism circumvented the API's immutable publishing design and was susceptible to serving images changed or deleted outside the publishing process.
- URL resolution is centralized in `PageService.getImageUrl(resource)` — the familiar API name, now taking the parsed `Resource` and returning the published-files URL (or `null` when the resource has no published file, in which case nothing renders). The old `getAnimationUrl`, `findAttachment`, and both lookup dictionaries (plus the attachments-index walk that populated them) are removed — net **−153 lines**.
- Image preloading now iterates `manifest.relatedFiles` and prefetches the published files directly. Note for @frett: `manifest.resources` isn't exposed in the godtools-shared npm typings (only `relatedFiles`) — `relatedFiles` covers the preload use case, but exposing `resources` would let us filter by resource type instead of file extension.
- The parser's `withLegacyWebImageResources` compat mode is **disabled** per the ticket. ✅ @frett's legacy web image check returned nothing — confirmed safe to remove.
- Heads-up: when #334 (GT-3052) merges, its button icon lookup (`resolveImage()` in `content-button.component.ts`) should be migrated to `PageService.getImageUrl(resource)` — a small reconciliation on whichever branch lands second.

Jira: [GT-3059](https://jira.cru.org/browse/GT-3059)

Verified live against staging: the `kgp` tract renders its content images from `/translations/files/{sha256}.png` with all prefetch links pointing at the published location (legacy mode off).

## Testing

- Run `yarn start:dev` and open http://localhost:4200/en/kgp/1 (or any staging tract with images)
- Check content images render, and in devtools confirm their `src` (and the `<link rel="prefetch">` tags in `<head>`) point at `https://mobile-content-api-stage.cru.org/translations/files/{sha256}.{ext}` — not at attachment file URLs
- Check a tool with Lottie animations plays them (animations resolve through the same published-files mechanism)
- Check a tool whose content is fully published shows no missing images; a resource without a published file now renders nothing instead of falling back to the attachments table
- `yarn test --no-watch` — 202/202 pass, including new `getImageUrl()` specs and a rewritten preload spec asserting the prefetch link hrefs

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [ ] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [ ] I have run `/agent-review` and addressed its findings before requesting a dev review
- [ ] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from a randomly-chosen team member
- [ ] I have tested my changes on staging or development
- [x] I have cleaned up my commit history

🤖 Generated with [Claude Code](https://claude.com/claude-code)
