### PR TITLE
[No Jira] - Fix outdated sharing targets

### DIFF
--- a/src/app/api/url.ts
+++ b/src/app/api/url.ts
@@ -13,11 +13,10 @@ export const APIURL = {
 };
 
 export const SHAREDURL = new Map([
-  ['GOOGLEPLUS', 'https://plusone.google.com/_/+1/confirm?url='],
   ['FACEBOOK', 'https://www.facebook.com/sharer/sharer.php?u='],
   [
     'TWITTER',
-    'https://twitter.com/home?status=BOOK_NAME via %40crutweets BOOK_LINK'
+    'https://x.com/intent/tweet?text=BOOK_NAME via %40crutweets&url=BOOK_LINK'
   ],
   ['MAILTO', 'mailto:?subject=MAIL_SUBJECT&body=MAIL_BODY']
 ]);

--- a/src/app/shared/sharing-modal/sharing-modal.component.html
+++ b/src/app/shared/sharing-modal/sharing-modal.component.html
@@ -17,9 +17,6 @@
       <a title="Facebook" class="btn" (click)="shareTo('FACEBOOK')">
         <div class="fab fa-facebook-f"></div>
       </a>
-      <a title="Google+" class="btn" (click)="shareTo('GOOGLEPLUS')">
-        <div class="fab fa-google-plus-g"></div>
-      </a>
       <a class="btn" (click)="shareTo('MAILTO')" title="Email">
         <div class="fas fa-envelope"></div>
       </a>

--- a/src/app/shared/sharing-modal/sharing-modal.component.spec.ts
+++ b/src/app/shared/sharing-modal/sharing-modal.component.spec.ts
@@ -22,4 +22,42 @@ describe('SharingModalComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('shares to the current X intent URL', () => {
+    component.book = 'Knowing God Personally';
+    const open = spyOn(window, 'open');
+
+    component.shareTo('TWITTER');
+
+    expect(open).toHaveBeenCalledWith(
+      `https://x.com/intent/tweet?text=Knowing God Personally via %40crutweets&url=${window.location.href}`,
+      '_blank'
+    );
+  });
+
+  it('keeps the Facebook and email sharing targets working', () => {
+    component.book = 'Knowing God Personally';
+    const open = spyOn(window, 'open');
+
+    component.shareTo('FACEBOOK');
+    component.shareTo('MAILTO');
+
+    expect(open.calls.allArgs()).toEqual([
+      [
+        `https://www.facebook.com/sharer/sharer.php?u=${window.location.href}`,
+        '_blank'
+      ],
+      [
+        `mailto:?subject=Knowing God Personally&body=${window.location.href}`,
+        '_blank'
+      ]
+    ]);
+  });
+
+  it('does not render the retired Google+ target', () => {
+    component.ShareState = 'max';
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[title="Google+"]')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Description

- Remove the retired Google+ share target.
- Update the Twitter share action to use the current X intent endpoint.
- Add controller coverage for X, Facebook, and email sharing, plus the absence of Google+.
- Keep the existing Twitter label and glyph so this focused fix does not introduce a new icon asset.

Closes #348

No screenshot is included because the only layout change is removal of the retired Google+ button.

Live endpoint checks:
- Facebook's share URL returned HTTP 200 and redirected to its share channel.
- X's exact intent URL was checked, but X returned HTTP 403 to headless curl in this environment; the generated URL and parameters are covered by the Karma test.

## Testing

- Targeted Karma controller tests: 4 passed
- `yarn build`
- Prettier on the touched files
- ESLint on the touched files: 0 errors (the HTML file is ignored by the existing configuration)

## Checklist

- [x] The change is focused on the reported sharing-target issue.
- [x] The PR title follows the project format.
- [ ] Required labels have been applied by a maintainer.
- [x] Linting and formatting checks were run.
- [x] Automated tests were added and pass.
- [ ] `/agent-review` has been run.
- [ ] Manually verified in the staging environment.
