### PR TITLE
Enable Renovate automerge for devDependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,11 @@
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
   "separateMultipleMajor": true,
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add a Renovate `packageRules` entry that enables automerge for all devDependency updates. Renovate will still wait for the required CI checks to pass before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)