### PR TITLE
Remove dependabot config and disable automerge on major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,10 @@
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,11 +8,8 @@
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Description

Remove Dependabot config since we rely on Rennovate.

Disable automerge on major devDependencies upgrades (@frett this seems wise for now).

## Checklist:

- [x] I have opened this PR against `staging` or `main` (CI only runs PR checks on those branches)
- [x] I have given my PR a title with the format "GT-(JIRA#) (summary sentence max 80 chars)" — the GT (GodTools) ticket prefix matches the Jira board; if there is no ticket, use "[No Jira] - (summary sentence max 80 chars)"
- [x] I have applied the appropriate labels — add **"On Staging"** to auto-merge this branch into `staging` and `development`, or **"On Development"** to merge into `development` only, so it deploys to a live test environment (see [`update-staging.yml`](.github/workflows/update-staging.yml))
- [x] I have run `yarn lint` and `yarn prettier:check` and fixed any issues
- [x] `yarn test --no-watch` passes locally
- [x] I have run `/agent-review` and addressed its findings before requesting a dev review
- [ ] My PR is ready for review and I have applied the **"Review"** label — this automatically requests a review from a randomly-chosen team member
- [ ] I have tested my changes on staging or development
- [ ] I have cleaned up my commit history
